### PR TITLE
docs: human-readable spec with RapiDoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The rationale behind defining a generic pinning service API is to have a baselin
 ## Specification
 
 * [ipfs-pinning-service.yaml](./ipfs-pinning-service.yaml) [![](https://github.com/ipfs/pinning-services-api-spec/workflows/Lint/badge.svg?branch=master)](https://github.com/ipfs/pinning-services-api-spec/actions?query=workflow%3ALint+branch%3Amaster) ![](https://img.shields.io/badge/status-wip-orange.svg?style=flat-square) 
+  * [Human-readable API docs](https://ipfs.github.io/pinning-services-api-spec/)
 
 ## Timeline
 
@@ -32,7 +33,7 @@ The rationale behind defining a generic pinning service API is to have a baselin
 - 2020 Q3
   - IPFS GUI Team looking into adding support for Pinning Services into Desktop apps
     - [Epic: Pinning service integration · Issue #91 · ipfs/ipfs-gui](https://github.com/ipfs/ipfs-gui/issues/91)
-    - **[WIP]** Analysis of Remote Pinning Services vs the needs of IPFS WebUI 
+    - [Analysis of Remote Pinning Services vs the needs of IPFS WebUI](https://docs.google.com/document/d/1f0R7woLtW_YTv9P9IOrUNK6QafgctJ7qTggEUdepD_c/)
   - [ipfs/pinning-services-api-specs](https://github.com/ipfs/pinning-services-api-specs) is created as a place for stakeholders to collaborate and finalize the API
 
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script  type="module" src="https://cdn.jsdelivr.net/npm/rapidoc@8.1.1/dist/rapidoc-min.js" integrity="sha256-2EZbv2gdEiAw80fEpBDlndxxsQya0C9yrhEtg4td99g=" crossorigin="anonymous"></script>
+  <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+</head>
+<body>
+  <rapi-doc
+    spec-url = "https://raw.githubusercontent.com/ipfs/pinning-services-api-spec/master/ipfs-pinning-service.yaml"
+    render-style = "read"
+    show-header = "false"
+    primary-color = "#0b3a53"
+    >
+    <img
+      slot="nav-logo"
+      src="https://ipfs.io/images/ipfs-logo.svg"
+    />
+  </rapi-doc>
+</body> 
+</html>


### PR DESCRIPTION
This PR adds human-readable docs for YAML in `master` 

Closes #4

(Merging as-is to make things easier to review, we can improve this in separate PRs)