### PR TITLE
v0.0.2: Pinning Summit + initial feedback

### DIFF
--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -2,50 +2,58 @@ openapi: 3.0.0
 info:
   version: "0.0.2"
   title: '(WIP) IPFS Pinning Service API'
-  description: "# About
+  description: "
+# About
 
-    This is the IPFS Pinning Service API. It attempts to be an
-    implementation-agnostic API designed to be implemented by Pinning Service
-    Providers and used in client mode by IPFS nodes and GUI applications.
+This is the IPFS Pinning Service API. It attempts to be an
+implementation-agnostic API designed to be implemented by Pinning Service
+Providers and used in client mode by IPFS nodes and GUI applications.
 
-    ## THIS SPEC IS WORK IN PROGRESS 🏗️
+## THIS SPEC IS WORK IN PROGRESS 🏗️
 
-    Join design discussion at  [https://github.com/ipfs/pinning-services-api-spec](https://github.com/ipfs/pinning-services-api-spec)
+Join design discussion at  [https://github.com/ipfs/pinning-services-api-spec](https://github.com/ipfs/pinning-services-api-spec)
 
-    # Pin object lifecycle
+# Pin object lifecycle
 
-    ## Creating pin
+## Creating a new pin
 
-    User creates pin object via `POST /pins` and receives `PinStatus` response
+User creates pin object via `POST /pins` and receives `PinStatus` response
 
-    - `id` in `PinStatus` is `cid-of-pin-object` that can be used for modifying and removing pin in the future
+- `id` in `PinStatus` is `cid-of-pin-object` that can be used for modifying
+  and removing pin in the future
 
-    - `status` in  `PinStatus` indicates current state of a pin
+- `status` in  `PinStatus` indicates current state of a pin
 
-    ### Checking status of pinning in progress
 
-    `status` from `PinStatus` may indicate a pending state. It means the data behind `Pin.cid` was not found on pinning service and is being fetched from IPFS network, which may take time.
+### Checking status of pinning in progress
 
-    In that case, user can periodically check pinning progress via `GET /pins/{cid-of-pin-object}`, until pinning is successful, or decides to remove pending pin.
+`status` from `PinStatus` may indicate a pending state. It means the data
+behind `Pin.cid` was not found on pinning service and is being fetched from
+IPFS network, which may take time.
 
-    ## Modifying pin object
+In that case, user can periodically check pinning progress via `GET
+/pins/{cid-of-pin-object}`, until pinning is successful, or decides to remove
+pending pin.
 
-    User may decide to modify existing pin object via `POST /pins/{cid-of-pin-object}`. The new pin object `id` is returned in `PinStatus` response. The old pin object is deleted automatically.
+## Modifying existing pin object
 
-    ## Removing pin object
+User may decide to modify existing pin object via `POST
+/pins/{cid-of-pin-object}`. The new pin object `id` is returned in `PinStatus`
+response. The old pin object is deleted automatically.
 
-    Pin object can be removed via `DELETE /pins/{cid-of-pin-object}`
+## Removing a pin object
 
-    # Authorization
+Pin object can be removed via `DELETE /pins/{cid-of-pin-object}`
 
-    An opaque auth token is required to be sent with each request.
-    There are two ways of doing so:
+# Authorization
 
-    - HTTP header: `Authorization: Bearer <auth>`
+An opaque auth token is required to be sent with each request.
+There are two ways of doing so:
 
-    - query parameter: `&auth=<auth>`
+- HTTP header: `Authorization: Bearer <auth>`
 
-  "
+- query parameter: `&auth=<auth>`
+"
 
 servers:
   - url: https://api.example.com
@@ -241,7 +249,7 @@ components:
         - unpinning  # (optional) unpinning in-progress
 
     Meta:
-      description: Optional metadata for Pin object
+      description: Optional metadata
       type: object
       additionalProperties:
         type: string

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -1,40 +1,44 @@
 openapi: 3.0.0
 info:
-  version: "0.0.1"
-  title: 'IPFS Pinning Service API'
-  description: "This is the IPFS Pinning Service API. It attempts to be an
+  version: "0.0.2"
+  title: '(WIP) IPFS Pinning Service API'
+  description: "# About
+
+    This is the IPFS Pinning Service API. It attempts to be an
     implementation-agnostic API designed to be implemented by Pinning Service
-    Providers.
+    Providers and used in client mode by IPFS nodes and GUI applications.
 
+    ## THIS SPEC IS WORK IN PROGRESS 🏗️
 
-    This specification does **NOT** define the IPFS pinning API.
+    Join design discussion at  [https://github.com/ipfs/pinning-services-api-spec](https://github.com/ipfs/pinning-services-api-spec)
 
+    # Authorization
 
-    GitHub discussion around this API can be found in [ipfs/pinning-services-api-spec](https://github.com/ipfs/pinning-services-api-spec).
+    An opaque auth token is required to be sent with each request.
+    There are two ways of doing so:
 
+    - HTTP header: `Authorization: Bearer <auth>`
 
+    - query parameter: `&auth=<auth>`
 
-    **Critical Notice**
-
-
-    To allow backend systems behind the API to associate pins with a particular
-    user, the API requires that a JSON Web Token is passed with requests that
-    contains a `sub` claim (as specified by
-    [OpenIDConnect Standard Claims](https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims))
-    that represents the user's identity within the backend system, so as to
-    associate the user with their pins. This allows the backend system to use
-    the identity as a form of reference counting on pins, therefore only
-    removing pins once no other users have it pinned."
+  "
 
 servers:
   - url: https://api.example.com
+
 paths:
   /pins:
     get:
-      summary: Get all pins
+      summary: List pin objects
+      description: List all the pin objects and status matching optional parameters
       tags:
         - pins
-      description: Get all the pins for the current user.
+      parameters:
+        - $ref: '#/components/parameters/cid'
+        - $ref: '#/components/parameters/status'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/auth'
       responses:
         '200':
           description: OK
@@ -49,10 +53,12 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
     post:
-      summary: Add an array of pins
+      summary: Add an array of pin objects
+      description: Add an array of pin objects for the current user
       tags:
         - pins
-      description: Add an array of pins for the current user.
+      parameters:
+        - $ref: '#/components/parameters/auth'
       requestBody:
         required: true
         content:
@@ -75,18 +81,21 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
-  /pins/{cid}:
+  /pins/{cid-of-pin-object}:
     parameters:
-      - name: cid
+      - name: cid-of-pin-object
         in: path
         required: true
         schema:
           type: string
+      - $ref: '#/components/parameters/auth'
     get:
-      summary: Get status of a Pin
+      summary: Get pin object
+      description: Get pin object with status
       tags:
         - pins
-      description: Get status of a Pin
+      parameters:
+        - $ref: '#/components/parameters/auth'
       responses:
         '200':
           description: OK
@@ -100,15 +109,21 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
-
     post:
-      parameters:
-        - $ref: '#/components/parameters/pinReplicationParam'
-        - $ref: '#/components/parameters/pinMetaParam'
-      summary: Add a new Pin
+      summary: Modify pin object
+      description: Modifies existing pin object
       tags:
         - pins
-      description: If the parameters are valid, the server will return an 'Accepted' response. T
+      parameters:
+        - $ref: '#/components/parameters/auth'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Pin'
       responses:
         '202':
           description: Accepted
@@ -123,10 +138,12 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
     delete:
-      summary: Remove a Pin
+      summary: Remove pin object
+      description: Remove pin object
       tags:
         - pins
-      description: Remove a Pin
+      parameters:
+        - $ref: '#/components/parameters/auth'
       responses:
         '202':
           description: Accepted
@@ -141,7 +158,51 @@ paths:
 
 components:
   schemas:
+
+    PinStatus:
+      description: Pin object with Status
+      type: object
+      properties:
+        pin:
+          $ref: '#/components/schemas/Pin'
+        status:
+          $ref: '#/components/schemas/Status'
+
+    Pin:
+      description: Pin object
+      type: object
+      properties:
+        cid:
+          description: CID to be pinned
+          type: string
+        depth:
+          description: Defines how deep the DAG should be pinned (-1 recursive, 0 direct)
+          type: integer
+          format: int32
+          default: -1
+          minimum: -1
+        meta:
+          $ref: '#/components/schemas/Meta'
+      required:
+      - cid
+
+    Status:
+      description: Status in which pin object can exist at a pinning service
+      type: string
+      enum:
+        - pinned
+        - pinning  # in-progress
+        - removing # in-progress
+        - expired  # still pinned for some time, but run out of funds and is not provided to the IPFS network
+
+    Meta:
+      description: Optional metadata for Pin object
+      type: object
+      additionalProperties:
+        type: string
+
     Error:
+      description: Base Error object
       type: object
       properties:
         code:
@@ -149,58 +210,79 @@ components:
         message:
           type: string
 
-    Cid:
-      type: object
-      properties:
-        /:
-          type: string
-
-    Metadata:
-      type: object
-      additionalProperties:
-        type: string
-
-    ReplicationFactor:
-      type: integer
-      minimum: -1
-
-    PinStatus:
-      type: object
-      properties:
-        peername:
-          type: string
-        peer:
-          type: string
-        error:
-          type: string
-        pin:
-          $ref: '#/components/schemas/Pin'
-        status:
-          type: string
-
-    Pin:
-      type: object
-      properties:
-        cid:
-          $ref: '#/components/schemas/Cid'
-        metadata:
-          $ref: '#/components/schemas/Metadata'
-        replication:
-          $ref: '#/components/schemas/ReplicationFactor'
-
   parameters:
-    pinReplicationParam:
-      name: replication
-      in: query
-      schema:
-        $ref: '#/components/schemas/ReplicationFactor'
 
-    pinMetaParam:
-      name: meta
-      description: Associate metadata strings with a Pin.
+    skip:
+      description: number of items to skip
+      name: skip
       in: query
+      required: false
       schema:
-        $ref: '#/components/schemas/Metadata'
+        type: integer
+        format: int32
+
+    limit:
+      description: max records to return
+      name: limit
+      in: query
+      required: false
+      schema:
+        type: integer
+        format: int32
+
+    cid:
+      description: return pin objects for the specified CID(s)
+      name: cid
+      in: query
+      required: false
+      schema:
+        type: array
+        items:
+          type: string
+      style: form
+      explode: false
+      examples:
+        oneId:
+          summary: Example of a single CID
+          value: [QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR]   # ?cid=Qm
+        multipleIds:
+          summary: Example of multiple CIDs
+          value: [QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR,bafkreigtdgsgv2f3bkhsmxvku3bpnnqzubcxeupf7fff5f7l7tlm2v237a]   # ?cid=Qm,bafy
+
+    depth:
+      description: return pin objects for all nodes under the specified DAG depth (requires root CID)
+      name: depth
+      in: query
+      required: false
+      schema:
+        type: string
+      examples:
+        recursive:
+          summary: Example of a recursive pin
+          value: -1
+        direct:
+          summary: Example of direct pin
+          value: 0
+
+    status:
+      description: return pin objects for pins in the specified status
+      name: status
+      in: query
+      required: false
+      schema:
+        type: array
+        items:
+          $ref: '#/components/schemas/Status'
+      style: form
+      explode: false
+
+    auth:
+      description: optional auth token (alternative to Authorization header)
+      name: auth
+      in: query
+      required: false
+      schema:
+        type: string
 
   responses:
     BadRequest:
@@ -242,7 +324,5 @@ components:
     tokenAuth:
       type: http
       scheme: bearer
-      bearerFormat: JWT
 security:
   - tokenAuth: []
-

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -36,6 +36,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/cid'
         - $ref: '#/components/parameters/status'
+        - $ref: '#/components/parameters/depth'
         - $ref: '#/components/parameters/skip'
         - $ref: '#/components/parameters/limit'
         - $ref: '#/components/parameters/auth'
@@ -239,7 +240,7 @@ components:
         type: array
         items:
           type: string
-      style: form
+      style: form # ?cid=Qm1,Qm2,bafy3
       explode: false
       examples:
         oneId:
@@ -250,7 +251,7 @@ components:
           value: [QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR,bafkreigtdgsgv2f3bkhsmxvku3bpnnqzubcxeupf7fff5f7l7tlm2v237a]   # ?cid=Qm,bafy
 
     depth:
-      description: return pin objects for all nodes under the specified DAG depth (requires root CID)
+      description: return pin objects only for pins with the specified depth
       name: depth
       in: query
       required: false
@@ -258,10 +259,10 @@ components:
         type: string
       examples:
         recursive:
-          summary: Example of a recursive pin
+          summary: recursive pin
           value: -1
         direct:
-          summary: Example of direct pin
+          summary: direct pin
           value: 0
 
     status:
@@ -273,7 +274,7 @@ components:
         type: array
         items:
           $ref: '#/components/schemas/Status'
-      style: form
+      style: form # ?status=a,b,c
       explode: false
 
     auth:

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -257,6 +257,7 @@ components:
       schema:
         type: integer
         format: int32
+        default: 0
 
     limit:
       description: max records to return

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -196,6 +196,10 @@ components:
     PinStatus:
       description: Pin object with Status
       type: object
+      required:
+        - id
+        - status
+        - pin
       properties:
         id:
           description: CID of Pin object that can be used for status checks of ongoing pinning
@@ -204,10 +208,14 @@ components:
           $ref: '#/components/schemas/Status'
         pin:
           $ref: '#/components/schemas/Pin'
+        meta:
+          $ref: '#/components/schemas/Meta'
 
     Pin:
       description: Pin object
       type: object
+      required:
+        - cid
       properties:
         cid:
           description: CID to be pinned
@@ -220,17 +228,17 @@ components:
           minimum: -1
         meta:
           $ref: '#/components/schemas/Meta'
-      required:
-      - cid
 
     Status:
       description: Status in which pin object can exist at a pinning service
       type: string
       enum:
-        - pinned
-        - pinning  # in-progress
-        - removing # in-progress
-        - expired  # still pinned for some time, but run out of funds and is not provided to the IPFS network
+        - resolving  # pinning in-progress: verifying pin request and looking for providers
+        - retrieving # pinning in-progress: connected to at least one provider and fetched at least one block
+        - pinned     # pinned successfully
+        - failed     # pining service was unable to finish pinning operation
+        - expired    # (optional) still pinned for some time, but run out of funds and won't be provided to the IPFS network
+        - unpinning  # (optional) unpinning in-progress
 
     Meta:
       description: Optional metadata for Pin object
@@ -241,6 +249,9 @@ components:
     Error:
       description: Base Error object
       type: object
+      required:
+        - code
+        - message
       properties:
         code:
           type: integer

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -267,6 +267,9 @@ components:
       schema:
         type: integer
         format: int32
+        minimum: 1
+        maximum: 1000
+        default: 1000
 
     cid:
       description: return pin objects for the specified CID(s)

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -60,7 +60,6 @@ paths:
       parameters:
         - $ref: '#/components/parameters/cid'
         - $ref: '#/components/parameters/status'
-        - $ref: '#/components/parameters/depth'
         - $ref: '#/components/parameters/skip'
         - $ref: '#/components/parameters/limit'
         - $ref: '#/components/parameters/auth'
@@ -286,21 +285,6 @@ components:
         multipleIds:
           summary: Example of multiple CIDs
           value: [QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR,bafkreigtdgsgv2f3bkhsmxvku3bpnnqzubcxeupf7fff5f7l7tlm2v237a]   # ?cid=Qm,bafy
-
-    depth:
-      description: return pin objects only for pins with the specified depth
-      name: depth
-      in: query
-      required: false
-      schema:
-        type: string
-      examples:
-        recursive:
-          summary: recursive pin
-          value: -1
-        direct:
-          summary: direct pin
-          value: 0
 
     status:
       description: return pin objects for pins in the specified status

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -12,6 +12,30 @@ info:
 
     Join design discussion at  [https://github.com/ipfs/pinning-services-api-spec](https://github.com/ipfs/pinning-services-api-spec)
 
+    # Pin object lifecycle
+
+    ## Creating pin
+
+    User creates pin object via `POST /pins` and receives `PinStatus` response
+
+    - `id` in `PinStatus` is `cid-of-pin-object` that can be used for modifying and removing pin in the future
+
+    - `status` in  `PinStatus` indicates current state of a pin
+
+    ### Checking status of pinning in progress
+
+    `status` from `PinStatus` may indicate a pending state. It means the data behind `Pin.cid` was not found on pinning service and is being fetched from IPFS network, which may take time.
+
+    In that case, user can periodically check pinning progress via `GET /pins/{cid-of-pin-object}`, until pinning is successful, or decides to remove pending pin.
+
+    ## Modifying pin object
+
+    User may decide to modify existing pin object via `POST /pins/{cid-of-pin-object}`. The new pin object `id` is returned in `PinStatus` response. The old pin object is deleted automatically.
+
+    ## Removing pin object
+
+    Pin object can be removed via `DELETE /pins/{cid-of-pin-object}`
+
     # Authorization
 
     An opaque auth token is required to be sent with each request.
@@ -71,6 +95,12 @@ paths:
       responses:
         '202':
           description: Accepted
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PinStatus'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -128,6 +158,10 @@ paths:
       responses:
         '202':
           description: Accepted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PinStatus'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -164,10 +198,13 @@ components:
       description: Pin object with Status
       type: object
       properties:
-        pin:
-          $ref: '#/components/schemas/Pin'
+        id:
+          description: CID of Pin object that can be used for status checks of ongoing pinning
+          type: string
         status:
           $ref: '#/components/schemas/Status'
+        pin:
+          $ref: '#/components/schemas/Pin'
 
     Pin:
       description: Pin object


### PR DESCRIPTION
This version is  following spec drafted during Pinning Summit where we switched API to operate on "pin objects" with some improvements based on initial feedback and discussions received from the community this week.

This is by no means the finished spec: goal is to close some topics and kick-off discussions on remaining items.

## Changes in this PR 

:question: – needs clarification or further discussion
⁉️– potentially controversial

- [x] Changes from Pinning Summit, namely change API to operate on "pin objects" (closes #2)
	- [x] Replaced vendors-specific fields such as `replicationParam` with a free form `meta`
- [x] Basic pagination with `skip` and `limit` parameters (closes #12)
- [x] Added ability to filter pin objects using arrays of CIDs and/or statuses (closes #1)
- [x] :question: simplified authorization based on opaque string that can be passed in HTTP header or query param, as suggested by @mikeal in https://github.com/ipfs/pinning-services-api-spec/issues/6#issuecomment-655056961
- [x] Examples and missing descriptions
- [x] :question: `Status` enum in which pin object can exist at a pinning service
      (for now those are just strings)
- [x] ⁉️ replaced "pin type" with more flexible `depth`
      It can represent direct (`0`) and recursive (`-1`) pins just fine, but opens more advanced strategies in the future. 
- <del> ⁉️ `GET /pins/?cid=Qm&depth=1` could return pin status of arbitrary subtree</del> `depth` is just a simple filter (direct/recursive)


## Documentation Preview

Docs for `feat/pinning-summit-variant-v0.0.2` branch can be viewed at:

- https://bafybeibarvujzcxuqikzdb22pzdbza4hz4rdvaagrcunjs7zhaqamw46ku.ipfs.dweb.link/



cc @pooja @jacobheun @aschmahmann @achingbrain @autonome @gozala @momack2 @olizilla 
@obo20 @sanderpick 