### PR TITLE
Replace Pin.depth with Pin.mode string enum

### DIFF
--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -228,12 +228,14 @@ components:
         cid:
           description: CID to be pinned
           type: string
-        depth:
-          description: Defines how deep the DAG should be pinned (-1 recursive, 0 direct)
-          type: integer
-          format: int32
-          default: -1
-          minimum: -1
+        mode:
+          description: Defines the mode of pin operation
+          type: string
+          enum:
+            - direct
+            - recursive
+            - pinset
+          default: recursive
         meta:
           $ref: '#/components/schemas/Meta'
 


### PR DESCRIPTION
> See also for alternative simpler boolean version.

This PR removes ambiguity of `depth: -1` for recursive pins (cc @ achingbrain) and enables arbitrary modes of pinning to be added in the future.

I included the third type named 'pinset', which could represent a well-known format for storing all local pins (cc @aschmahmann, we discussed something like this last week), but we can remove it if its not feasible atm.

cc @obo20 