### PR TITLE
Remove Pin.depth and add meta examples

### DIFF
--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -56,8 +56,6 @@ leveraging optional `meta` attributes:
 
 - `Pin.meta[replication]` – could define how many copies service should keep
 
-- `Pin.meta[depth]` – could define how deep the DAG should be pinned
-
 - `Pin.meta[providers] = ['multiaddr1','multiaddr2']` list of peers that are known to have pinned data
 
 Those can be vendor-specific, but we encourrage community to leverage `meta` to

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -257,7 +257,7 @@ components:
         - resolving  # pinning in-progress: verifying pin request and looking for providers
         - retrieving # pinning in-progress: connected to at least one provider and fetched at least one block
         - pinned     # pinned successfully
-        - failed     # pining service was unable to finish pinning operation, additional details can be foun in meta[fail_reason]
+        - failed     # pining service was unable to finish pinning operation, details can be found in meta[fail_reason]
         - expired    # (optional) still pinned for some time, but run out of funds and won't be provided to the IPFS network
         - unpinning  # (optional) unpinning in-progress
 

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -50,7 +50,9 @@ Pin object can be removed via `DELETE /pins/{cid-of-pin-object}`
 Pinning Services are encouraged to add support for additional features by
 leveraging optional `meta` attributes:
 
-- `PinStatus.meta[progress]` –  % progress of ongoing pinning operation
+- `PinStatus.meta[progress]` –  % progress of ongoing pinning operation (if possible to tell)
+
+- `PinStatus.meta[fail_reason]` - service-specific reason why pin operation failed (eg. lack of funds, DAG too big etc)
 
 - `PinStatus.meta[receivers] = ['multiaddr1','multiaddr2']` list of peers to connect to to speed up transfer of pinned data
 
@@ -255,7 +257,7 @@ components:
         - resolving  # pinning in-progress: verifying pin request and looking for providers
         - retrieving # pinning in-progress: connected to at least one provider and fetched at least one block
         - pinned     # pinned successfully
-        - failed     # pining service was unable to finish pinning operation
+        - failed     # pining service was unable to finish pinning operation, additional details can be foun in meta[fail_reason]
         - expired    # (optional) still pinned for some time, but run out of funds and won't be provided to the IPFS network
         - unpinning  # (optional) unpinning in-progress
 

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -60,7 +60,7 @@ leveraging optional `meta` attributes:
 
 - `Pin.meta[providers] = ['multiaddr1','multiaddr2']` list of peers that are known to have pinned data
 
-Those can be vendor-specific, but we encourrage community to leverage `meta` to
+Those can be vendor-specific, but we encourage community to leverage `meta` to
 come up with conventions that could become part of mandatory revisions of this
 API.
 

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -51,8 +51,14 @@ Pinning Services are encouraged to add support for additional features by
 leveraging optional `meta` attributes:
 
 - `PinStatus.meta[progress]` –  % progress of ongoing pinning operation
+
+- `PinStatus.meta[receivers] = ['multiaddr1','multiaddr2']` list of peers to connect to to speed up transfer of pinned data
+
 - `Pin.meta[replication]` – could define how many copies service should keep
+
 - `Pin.meta[depth]` – could define how deep the DAG should be pinned
+
+- `Pin.meta[providers] = ['multiaddr1','multiaddr2']` list of peers that are known to have pinned data
 
 Those can be vendor-specific, but we encourrage community to leverage `meta` to
 come up with conventions that could become part of mandatory revisions of this

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -45,6 +45,19 @@ response. The old pin object is deleted automatically.
 
 Pin object can be removed via `DELETE /pins/{cid-of-pin-object}`
 
+# Custom metadata
+
+Pinning Services are encouraged to add support for additional features by
+leveraging optional `meta` attributes:
+
+- `PinStatus.meta[progress]` –  % progress of ongoing pinning operation
+- `Pin.meta[replication]` – could define how many copies service should keep
+- `Pin.meta[depth]` – could define how deep the DAG should be pinned
+
+Those can be vendor-specific, but we encourrage community to leverage `meta` to
+come up with conventions that could become part of mandatory revisions of this
+API.
+
 # Authorization
 
 An opaque auth token is required to be sent with each request.
@@ -228,12 +241,6 @@ components:
         cid:
           description: CID to be pinned
           type: string
-        depth:
-          description: Defines how deep the DAG should be pinned (-1 recursive, 0 direct)
-          type: integer
-          format: int32
-          default: -1
-          minimum: -1
         meta:
           $ref: '#/components/schemas/Meta'
 

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -61,8 +61,11 @@ leveraging optional `meta` attributes:
 - `Pin.meta[providers] = ['multiaddr1','multiaddr2']` list of peers that are known to have pinned data
 
 Those can be vendor-specific, but we encourage community to leverage `meta` to
-come up with conventions that could become part of mandatory revisions of this
-API.
+come up with conventions that could become part of future revisions of this
+API. 
+
+It is ok to ommit or ignore `meta` attributes.  
+Doing so should not impact the basic pinning functionality.  
 
 # Authorization
 


### PR DESCRIPTION
This PR 

- <del>moves `depth` from being a mandatory field to optional `meta` attributes. 
  (as per feedback in https://github.com/ipfs/pinning-services-api-spec/pull/16)</del> Removed as per https://github.com/ipfs/pinning-services-api-spec/pull/19#discussion_r453685376
- documents various uses of `meta` fields, including peering hints to speed up transfer of data that is not already on the pinning service (closes #18, as per feedback in https://github.com/ipfs/pinning-services-api-spec/issues/18#issuecomment-656778692)


cc @obo20 @achingbrain 