### PR TITLE
Limit size of param and request/response arrays

### DIFF
--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -77,9 +77,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/PinStatus'
+                $ref: '#/components/schemas/PinResults'
         '400':
           $ref: '#/components/responses/BadRequest'
         '500':
@@ -101,19 +99,14 @@ paths:
                 $ref: '#/components/schemas/Pin'
               uniqueItems: true
               minItems: 1
-              maxItems: 100
+              maxItems: 1000
       responses:
         '202':
           description: Accepted
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/PinStatus'
-                uniqueItems: true
-                minItems: 1
-                maxItems: 100
+                $ref: '#/components/schemas/PinResults'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -206,6 +199,27 @@ paths:
 
 components:
   schemas:
+
+    PinResults:
+      description: Response used for listing Pin objects matching request
+      type: object
+      required:
+        - count
+        - results
+      properties:
+        count:
+          description: The total number of pin objects that exist for passed query filters
+          type: integer
+          format: int32
+          minimum: 0
+        results:
+          description: An array of PinStatus results
+          type: array
+          items:
+            $ref: '#/components/schemas/PinStatus'
+          uniqueItems: true
+          minItems: 0
+          maxItems: 1000
 
     PinStatus:
       description: Pin object with Status
@@ -307,7 +321,7 @@ components:
           type: string
         uniqueItems: true
         minItems: 1
-        maxItems: 100
+        maxItems: 1000
       style: form # ?cid=Qm1,Qm2,bafy3
       explode: false
       examples:

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -299,6 +299,9 @@ components:
         type: array
         items:
           type: string
+        uniqueItems: true
+        minItems: 1
+        maxItems: 100
       style: form # ?cid=Qm1,Qm2,bafy3
       explode: false
       examples:
@@ -318,6 +321,8 @@ components:
         type: array
         items:
           $ref: '#/components/schemas/Status'
+        uniqueItems: true
+        minItems: 1
       style: form # ?status=a,b,c
       explode: false
 

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -99,6 +99,9 @@ paths:
               type: array
               items:
                 $ref: '#/components/schemas/Pin'
+              uniqueItems: true
+              minItems: 1
+              maxItems: 100
       responses:
         '202':
           description: Accepted
@@ -108,6 +111,9 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/PinStatus'
+                uniqueItems: true
+                minItems: 1
+                maxItems: 100
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':


### PR DESCRIPTION
This PR 

- adds `PinResults`  object
  - `PinResults.count` indicates the size of total number of results for pagination
     (closes #12 as per feedback in https://github.com/ipfs/pinning-services-api-spec/issues/12#issuecomment-656425010)
  -  Makes it easier to set hard limits on the number of responses for a single query
- adds explicit limits on filter results (`cid` and `status`), as per feedback in https://github.com/ipfs/pinning-services-api-spec/issues/15#issuecomment-656742892 and closes #15


**Docs preview for this PR:** https://bafybeid6e52x5oyeeefa27r3yszp7r64j6i4tekznjkoqvc4tw3qh3sxry.ipfs.dweb.link/

----

@obo20 this change adds hard limit to all arrays (params and in `/pins` request/response):
```
maxItems: 1000
```

Let us know if this is ok or should be adjusted (we'd like to keep the same limit everywhere, for simplicity)