### PR TITLE
Make providers a required field

### DIFF
--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -253,7 +253,7 @@ components:
         pin:
           $ref: '#/components/schemas/Pin'
         providers:
-          $ref: '#/components/schemas/Providers'
+          $ref: '#/components/schemas/ServiceProviders'
         meta:
           $ref: '#/components/schemas/Meta'
 
@@ -262,13 +262,12 @@ components:
       type: object
       required:
         - cid
-        - providers
       properties:
         cid:
           description: CID to be pinned recursively
           type: string
         providers:
-          $ref: '#/components/schemas/Providers'
+          $ref: '#/components/schemas/DataProviders'
         meta:
           $ref: '#/components/schemas/Meta'
 
@@ -283,14 +282,23 @@ components:
         - expired    # (optional) still pinned for some time, but run out of funds and won't be provided to the IPFS network
         - unpinning  # (optional) unpinning in-progress
 
-    Providers:
-      description: List of multiaddrs designated or known to provide the pinned data.
+    ServiceProviders:
+      description: list of multiaddrs designated by pinning service for transferring any new data from external peers
+      type: array
+      items:
+        type: string
+      uniqueItems: true
+      minItems: 1
+      maxItems: 20
+
+    DataProviders:
+      description: optional list of multiaddrs known to provide the data
       type: array
       items:
         type: string
       uniqueItems: true
       minItems: 0
-      maxItems: 1000
+      maxItems: 20
 
     Meta:
       description: Optional metadata

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -45,6 +45,23 @@ response. The old pin object is deleted automatically.
 
 Pin object can be removed via `DELETE /pins/{cid-of-pin-object}`
 
+
+# Provider hints
+
+Pinning of new data can be accelerated by providing a list of known data
+sources in `Pin.providers` and connecting at least one of them to pinning
+service nodes at `PinStatus.providers`.
+
+
+The most common scenario is a client putting own IPFS node's multiaddrs in
+`Pin.providers`  and then directly connecting to every multiaddr returned by
+Pinning Service in `PinStatus.providers` to initiate transfer.
+
+
+This ensures data transfer starts immediately (without waiting for provider
+discovery over DHT) and direct dial from a client works around peer routing
+issues in restrictive network topologies such as NAT.
+
 # Custom metadata
 
 Pinning Services are encouraged to add support for additional features by
@@ -54,11 +71,7 @@ leveraging optional `meta` attributes:
 
 - `PinStatus.meta[fail_reason]` - service-specific reason why pin operation failed (eg. lack of funds, DAG too big etc)
 
-- `PinStatus.meta[receivers] = ['multiaddr1','multiaddr2']` list of peers to connect to to speed up transfer of pinned data
-
 - `Pin.meta[replication]` – could define how many copies service should keep
-
-- `Pin.meta[providers] = ['multiaddr1','multiaddr2']` list of peers that are known to have pinned data
 
 Those can be vendor-specific, but we encourage community to leverage `meta` to
 come up with conventions that could become part of future revisions of this
@@ -230,6 +243,7 @@ components:
         - id
         - status
         - pin
+        - providers
       properties:
         id:
           description: CID of Pin object that can be used for status checks of ongoing pinning
@@ -238,6 +252,8 @@ components:
           $ref: '#/components/schemas/Status'
         pin:
           $ref: '#/components/schemas/Pin'
+        providers:
+          $ref: '#/components/schemas/Providers'
         meta:
           $ref: '#/components/schemas/Meta'
 
@@ -246,10 +262,13 @@ components:
       type: object
       required:
         - cid
+        - providers
       properties:
         cid:
-          description: CID to be pinned
+          description: CID to be pinned recursively
           type: string
+        providers:
+          $ref: '#/components/schemas/Providers'
         meta:
           $ref: '#/components/schemas/Meta'
 
@@ -263,6 +282,15 @@ components:
         - failed     # pining service was unable to finish pinning operation, details can be found in meta[fail_reason]
         - expired    # (optional) still pinned for some time, but run out of funds and won't be provided to the IPFS network
         - unpinning  # (optional) unpinning in-progress
+
+    Providers:
+      description: List of multiaddrs designated or known to provide the pinned data.
+      type: array
+      items:
+        type: string
+      uniqueItems: true
+      minItems: 0
+      maxItems: 1000
 
     Meta:
       description: Optional metadata


### PR DESCRIPTION
This PR adds `Pin.providers` and `PinStatus.providers` as lists of max 20 multiaddrs. 

- `Pin.providers` is now optional and can be empty
- `PinStatus.providers` is now mandatory and needs to  have at least one multiaddr 

The goal is to encourage pinning services to provide own multiaddrs in pin response under  `PinStatus.providers` to ensure clients behind restrictive NAT can dial back and reach pinning service to facilitate data transfer.



As per
https://github.com/ipfs/pinning-services-api-spec/issues/22#issuecomment-657788004
https://github.com/ipfs/pinning-services-api-spec/issues/22#issuecomment-657793428

Closes #22 cc @obo20 
