### PR TITLE
Copy edits for consistency

### DIFF
--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -21,10 +21,10 @@ Your input and feedback are welcome and valuable as we develop this API spec. Pl
 
 The user creates a pin object via `POST /pins` and receives a `PinStatus` response:
 
-- `id` in `PinStatus` is `cid-of-pin-object`, which can can be used for modifying
+x `id` in `PinStatus` is `cid-of-pin-object`, which can can be used for modifying
   and/or removing the pin in the future
 
-- `status` in  `PinStatus` indicates the current state of a pin
+x `status` in  `PinStatus` indicates the current state of a pin
 
 
 ### Checking status of in-progress pinning
@@ -52,15 +52,15 @@ A pin object can be removed via `DELETE /pins/{cid-of-pin-object}`.
 Pinning services are encouraged to add support for additional features by leveraging the following optional `meta` attributes. Note that it is OK to ommit or ignore `meta` attributes;  
 doing so should not impact the basic pinning functionality.  
 
-- `PinStatus.meta[progress]`: Progress (as percent value) of an ongoing pinning operation, if possible to tell
+x `PinStatus.meta[progress]`: Progress (as percent value) of an ongoing pinning operation, if possible to tell
 
-- `PinStatus.meta[fail_reason]`: A service-specific reason why a pin operation failed (e.g. lack of funds, DAG too big, etc.)
+x `PinStatus.meta[fail_reason]`: A service-specific reason why a pin operation failed (e.g. lack of funds, DAG too big, etc.)
 
-- `PinStatus.meta[receivers] = ['multiaddr1','multiaddr2']`: A list of peers to which the user can connect in order to speed up transfer of pinned data
+x `PinStatus.meta[receivers] = ['multiaddr1','multiaddr2']`: A list of peers to which the user can connect in order to speed up transfer of pinned data
 
-- `Pin.meta[replication]`: This attribute could define how many copies a pinning service should keep
+x `Pin.meta[replication]`: This attribute could define how many copies a pinning service should keep
 
-- `Pin.meta[providers] = ['multiaddr1','multiaddr2']`: A list of peers that are known to have pinned data
+x `Pin.meta[providers] = ['multiaddr1','multiaddr2']`: A list of peers that are known to have pinned data
 
 
 While these attributes can be vendor-specific, we encourage the community at large to leverage these `meta` attributes as a sandbox to come up with conventions that could become part of future revisions of this API. 
@@ -69,9 +69,9 @@ While these attributes can be vendor-specific, we encourage the community at lar
 
 An opaque authorization token is required to be sent with each request. There are two ways of doing so:
 
-1. Using an HTTP header: `Authorization: Bearer <auth>`
+1 Using an HTTP header: `Authorization: Bearer <auth>`
 
-2. Using a query parameter: `&auth=<auth>`
+2 Using a query parameter: `&auth=<auth>`
 "
 
 servers:

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -9,7 +9,7 @@ info:
 <li>For use and implementation by pinning service providers</li>
 <li>For use in client mode by IPFS nodes and GUI-based applications</li>
 </ul>
-<h3>This spec is a work in progress! &#127959;</h3>
+<h2>This spec is a work in progress! &#127959;</h2>
 <p><strong>Your input and feedback are welcome and valuable as we develop this API spec. Please join the design discussion at <a href=\"https://github.com/ipfs/pinning-services-api-spec\" target=\"_blank\">github.com/ipfs/pinning-services-api-spec</a>.</strong></p>
 <h1>The pin object lifecycle</h1>
 <h2>Creating a new pin object</h2>

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -27,6 +27,7 @@ The IPFS Pinning Service API is intended to be an implementation-agnostic API&#x
 The user creates a pin object via <code>POST /pins</code> and receives a <code>PinStatus</code> response&#x3a;
 
 - `id` in `PinStatus` is `cid-of-pin-object`, which can can be used for modifying and/or removing the pin in the future
+
 - `status` in `PinStatus` indicates the current state of a pin
 
 
@@ -52,9 +53,13 @@ A pin object can be removed via `DELETE /pins/{cid-of-pin-object}`.
 Pinning services are encouraged to add support for additional features by leveraging the following optional `meta` attributes. Note that it is OK to ommit or ignore `meta` attributes; doing so should not impact the basic pinning functionality.
 
 - `PinStatus.meta[progress]`&#x3a; Progress (as percent value) of an ongoing pinning operation, if possible to tell
+
 - `PinStatus.meta[fail_reason]`&#x3a; A service-specific reason why a pin operation failed (e.g. lack of funds, DAG too big, etc.)
+
 - `PinStatus.meta[receivers] = ['multiaddr1','multiaddr2']`&#x3a; A list of peers to which the user can connect in order to speed up transfer of pinned data
+
 - `Pin.meta[replication]`&#x3a; This attribute could define how many copies a pinning service should keep
+
 - `Pin.meta[providers] = ['multiaddr1','multiaddr2']`&#x3a; A list of peers that are known to have pinned data
 
 While these attributes can be vendor-specific, we encourage the community at large to leverage these `meta` attributes as a sandbox to come up with conventions that could become part of future revisions of this API.
@@ -65,6 +70,7 @@ While these attributes can be vendor-specific, we encourage the community at lar
 An opaque authorization token is required to be sent with each request. There are two ways of doing so&#x3a;
 
 1. Using an HTTP header&#x3a; `Authorization&#x3a; Bearer <auth>`
+
 2. Using a query parameter&#x3a; `&auth=<auth>`
 
 "

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -6,9 +6,10 @@ info:
 # About this API
 
 The IPFS Pinning Service API is intended to be an implementation-agnostic API: 
-
-- For use and implementation by pinning service providers 
-- For use in client mode by IPFS nodes and GUI-based applications
+<ul>
+<li>For use and implementation by pinning service providers</li>
+<li>For use in client mode by IPFS nodes and GUI-based applications</li>
+</ul>
 
 ### This spec is a work in progress! 🏗️
 

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -32,7 +32,7 @@ info:
 <li><code>PinStatus.meta[fail_reason]</code>&#x3a; A service-specific reason why a pin operation failed (e.g. lack of funds, DAG too big, etc.)</li>
 <li><code>PinStatus.meta[receivers] = ['multiaddr1','multiaddr2']</code>&#x3a; A list of peers to which the user can connect in order to speed up transfer of pinned data</li>
 <li><code>Pin.meta[replication]</code>&#x3a; This attribute could define how many copies a pinning service should keep</li>
-<li><code>Pin.meta[providers] = ['multiaddr1','multiaddr2']<,code>&#x3a; A list of peers that are known to have pinned data</li>
+<li><code>Pin.meta[providers] = ['multiaddr1','multiaddr2']</code>&#x3a; A list of peers that are known to have pinned data</li>
 </ul>
 <p>While these attributes can be vendor-specific, we encourage the community at large to leverage these <code>meta</code> attributes as a sandbox to come up with conventions that could become part of future revisions of this API.</p> 
 <h1>Authorization</h1>

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -16,7 +16,7 @@ The IPFS Pinning Service API is intended to be an implementation-agnostic API&#x
 
 ## This spec is a work in progress! 🏗️
 
-**Your input and feedback are welcome and valuable as we develop this API spec. Please join the design discussion at [https://github.com/ipfs/pinning-services-api-spec](github.com/ipfs/pinning-services-api-spec).**
+**Your input and feedback are welcome and valuable as we develop this API spec. Please join the design discussion at [github.com/ipfs/pinning-services-api-spec](https://github.com/ipfs/pinning-services-api-spec).**
 
 
 # The pin object lifecycle
@@ -24,7 +24,7 @@ The IPFS Pinning Service API is intended to be an implementation-agnostic API&#x
 
 ## Creating a new pin object
 
-The user creates a pin object via <code>POST /pins</code> and receives a <code>PinStatus</code> response&#x3a;
+The user creates a pin object via `POST /pins` and receives a `PinStatus` response:
 
 - `id` in `PinStatus` is `cid-of-pin-object`, which can can be used for modifying and/or removing the pin in the future
 
@@ -34,6 +34,7 @@ The user creates a pin object via <code>POST /pins</code> and receives a <code>P
 ### Checking status of in-progress pinning
 
 `status` (in `PinStatus`) may indicate a pending state. This means the data behind `Pin.cid` was not found on the pinning service and is being fetched from the IPFS network at large, which may take time.
+
 
 In this case, the user can periodically check pinning progress via `GET /pins/{cid-of-pin-object}` until pinning is successful, or the user decides to remove the pending pin.
 
@@ -52,26 +53,27 @@ A pin object can be removed via `DELETE /pins/{cid-of-pin-object}`.
 
 Pinning services are encouraged to add support for additional features by leveraging the following optional `meta` attributes. Note that it is OK to ommit or ignore `meta` attributes; doing so should not impact the basic pinning functionality.
 
-- `PinStatus.meta[progress]`&#x3a; Progress (as percent value) of an ongoing pinning operation, if possible to tell
+- `PinStatus.meta[progress]`: Progress (as percent value) of an ongoing pinning operation, if possible to tell
 
-- `PinStatus.meta[fail_reason]`&#x3a; A service-specific reason why a pin operation failed (e.g. lack of funds, DAG too big, etc.)
+- `PinStatus.meta[fail_reason]`: A service-specific reason why a pin operation failed (e.g. lack of funds, DAG too big, etc.)
 
-- `PinStatus.meta[receivers] = ['multiaddr1','multiaddr2']`&#x3a; A list of peers to which the user can connect in order to speed up transfer of pinned data
+- `PinStatus.meta[receivers] = ['multiaddr1','multiaddr2']`: A list of peers to which the user can connect in order to speed up transfer of pinned data
 
-- `Pin.meta[replication]`&#x3a; This attribute could define how many copies a pinning service should keep
+- `Pin.meta[replication]`: This attribute could define how many copies a pinning service should keep
 
-- `Pin.meta[providers] = ['multiaddr1','multiaddr2']`&#x3a; A list of peers that are known to have pinned data
+- `Pin.meta[providers] = ['multiaddr1','multiaddr2']`: A list of peers that are known to have pinned data
+
 
 While these attributes can be vendor-specific, we encourage the community at large to leverage these `meta` attributes as a sandbox to come up with conventions that could become part of future revisions of this API.
 
 
 # Authorization
 
-An opaque authorization token is required to be sent with each request. There are two ways of doing so&#x3a;
+An opaque authorization token is required to be sent with each request. There are two ways of doing so:
 
-1. Using an HTTP header&#x3a; `Authorization&#x3a; Bearer <auth>`
+1. Using an HTTP header: `Authorization: Bearer <auth>`
 
-2. Using a query parameter&#x3a; `&auth=<auth>`
+2. Using a query parameter: `&auth=<auth>`
 
 "
 

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -3,44 +3,68 @@ info:
   version: "0.0.2"
   title: '(WIP) IPFS Pinning Service API'
   description: "
-<h1>Overview</h1>
-<p>The IPFS Pinning Service API is intended to be an implementation-agnostic API&#x3a;</p>
-<ul>
-<li>For use and implementation by pinning service providers</li>
-<li>For use in client mode by IPFS nodes and GUI-based applications</li>
-</ul>
-<h2>This spec is a work in progress! &#127959;</h2>
-<p><strong>Your input and feedback are welcome and valuable as we develop this API spec. Please join the design discussion at <a href=\"https://github.com/ipfs/pinning-services-api-spec\" target=\"_blank\">github.com/ipfs/pinning-services-api-spec</a>.</strong></p>
-<h1>The pin object lifecycle</h1>
-<h2>Creating a new pin object</h2>
-<p>The user creates a pin object via <code>POST /pins</code> and receives a <code>PinStatus</code> response&#x3a;</p>
-<ul>
-<li><code>id</code> in <code>PinStatus</code> is <code>cid-of-pin-object</code>, which can can be used for modifying and/or removing the pin in the future</li>
-<li><code>status</code> in <code>PinStatus</code> indicates the current state of a pin</li>
-</ul>
-<h3>Checking status of in-progress pinning</h3>
-<p><code>status</code> (in <code>PinStatus</code>) may indicate a pending state. This means the data behind <code>Pin.cid</code> was not found on the pinning service and is being fetched from the IPFS network at large, which may take time.</p>
-<p>In this case, the user can periodically check pinning progress via <code>GET /pins/{cid-of-pin-object}</code> until pinning is successful, or the user decides to remove the pending pin.</p>
-<h2>Modifying an existing pin object</h2>
-<p>The user can modify an existing pin object via <code>POST /pins/{cid-of-pin-object}</code>. The new pin object <code>id</code> is returned in the <code>PinStatus</code> response. The old pin object is deleted automatically.</p>
-<h2>Removing a pin object</h2>
-<p>A pin object can be removed via <code>DELETE /pins/{cid-of-pin-object}</code>.</p>
-<h1>Custom metadata</h1>
-<p>Pinning services are encouraged to add support for additional features by leveraging the following optional <code>meta</code> attributes. Note that it is OK to ommit or ignore <code>meta</code> attributes; doing so should not impact the basic pinning functionality.</p>
-<ul>
-<li><code>PinStatus.meta[progress]</code>&#x3a; Progress (as percent value) of an ongoing pinning operation, if possible to tell</li>
-<li><code>PinStatus.meta[fail_reason]</code>&#x3a; A service-specific reason why a pin operation failed (e.g. lack of funds, DAG too big, etc.)</li>
-<li><code>PinStatus.meta[receivers] = ['multiaddr1','multiaddr2']</code>&#x3a; A list of peers to which the user can connect in order to speed up transfer of pinned data</li>
-<li><code>Pin.meta[replication]</code>&#x3a; This attribute could define how many copies a pinning service should keep</li>
-<li><code>Pin.meta[providers] = ['multiaddr1','multiaddr2']</code>&#x3a; A list of peers that are known to have pinned data</li>
-</ul>
-<p>While these attributes can be vendor-specific, we encourage the community at large to leverage these <code>meta</code> attributes as a sandbox to come up with conventions that could become part of future revisions of this API.</p> 
-<h1>Authorization</h1>
-<p>An opaque authorization token is required to be sent with each request. There are two ways of doing so&#x3a;</p>
-<ol>
-<li>Using an HTTP header&#x3a; <code>Authorization&#x3a; Bearer <auth></code></li>
-<li>Using a query parameter&#x3a; <code>&auth=<auth></code></li>
-</ol>
+  
+  
+# Overview
+The IPFS Pinning Service API is intended to be an implementation-agnostic API&#x3a;
+
+- For use and implementation by pinning service providers
+- For use in client mode by IPFS nodes and GUI-based applications
+
+
+## This spec is a work in progress! 🏗️
+
+**Your input and feedback are welcome and valuable as we develop this API spec. Please join the design discussion at [https://github.com/ipfs/pinning-services-api-spec](github.com/ipfs/pinning-services-api-spec).**
+
+
+# The pin object lifecycle
+
+
+## Creating a new pin object
+
+The user creates a pin object via <code>POST /pins</code> and receives a <code>PinStatus</code> response&#x3a;
+
+- `id` in `PinStatus` is `cid-of-pin-object`, which can can be used for modifying and/or removing the pin in the future
+- `status` in `PinStatus` indicates the current state of a pin
+
+
+### Checking status of in-progress pinning
+
+`status` (in `PinStatus`) may indicate a pending state. This means the data behind `Pin.cid` was not found on the pinning service and is being fetched from the IPFS network at large, which may take time.
+
+In this case, the user can periodically check pinning progress via `GET /pins/{cid-of-pin-object}` until pinning is successful, or the user decides to remove the pending pin.
+
+
+## Modifying an existing pin object
+
+The user can modify an existing pin object via `POST /pins/{cid-of-pin-object}`. The new pin object `id` is returned in the `PinStatus` response. The old pin object is deleted automatically.
+
+
+## Removing a pin object
+
+A pin object can be removed via `DELETE /pins/{cid-of-pin-object}`.
+
+
+# Custom metadata
+
+Pinning services are encouraged to add support for additional features by leveraging the following optional `meta` attributes. Note that it is OK to ommit or ignore `meta` attributes; doing so should not impact the basic pinning functionality.
+
+- `PinStatus.meta[progress]`&#x3a; Progress (as percent value) of an ongoing pinning operation, if possible to tell
+- `PinStatus.meta[fail_reason]`&#x3a; A service-specific reason why a pin operation failed (e.g. lack of funds, DAG too big, etc.)
+- `PinStatus.meta[receivers] = ['multiaddr1','multiaddr2']`&#x3a; A list of peers to which the user can connect in order to speed up transfer of pinned data
+- `Pin.meta[replication]`&#x3a; This attribute could define how many copies a pinning service should keep
+- `Pin.meta[providers] = ['multiaddr1','multiaddr2']`&#x3a; A list of peers that are known to have pinned data
+
+While these attributes can be vendor-specific, we encourage the community at large to leverage these `meta` attributes as a sandbox to come up with conventions that could become part of future revisions of this API.
+
+
+# Authorization
+
+An opaque authorization token is required to be sent with each request. There are two ways of doing so&#x3a;
+
+1. Using an HTTP header&#x3a; `Authorization&#x3a; Bearer <auth>`
+2. Using a query parameter&#x3a; `&auth=<auth>`
+
 "
 
 servers:

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -5,7 +5,7 @@ info:
   description: "
 # About this API
 
-The IPFS Pinning Service API is intended to be an implementation-agnostic API: 
+The IPFS Pinning Service API is intended to be an implementation-agnostic API&#x3a;
 <ul>
 <li>For use and implementation by pinning service providers</li>
 <li>For use in client mode by IPFS nodes and GUI-based applications</li>
@@ -19,13 +19,12 @@ Your input and feedback are welcome and valuable as we develop this API spec. Pl
 
 ## Creating a new pin object
 
-The user creates a pin object via `POST /pins` and receives a `PinStatus` response:
+The user creates a pin object via `POST /pins` and receives a `PinStatus` response&#x3a;
 
-x `id` in `PinStatus` is `cid-of-pin-object`, which can can be used for modifying
-  and/or removing the pin in the future
-
-x `status` in  `PinStatus` indicates the current state of a pin
-
+<ul>
+<li>`id` in `PinStatus` is `cid-of-pin-object`, which can can be used for modifying and/or removing the pin in the future</li>
+<li>`status` in  `PinStatus` indicates the current state of a pin</li>
+</ul>
 
 ### Checking status of in-progress pinning
 
@@ -52,26 +51,24 @@ A pin object can be removed via `DELETE /pins/{cid-of-pin-object}`.
 Pinning services are encouraged to add support for additional features by leveraging the following optional `meta` attributes. Note that it is OK to ommit or ignore `meta` attributes;  
 doing so should not impact the basic pinning functionality.  
 
-x `PinStatus.meta[progress]`: Progress (as percent value) of an ongoing pinning operation, if possible to tell
-
-x `PinStatus.meta[fail_reason]`: A service-specific reason why a pin operation failed (e.g. lack of funds, DAG too big, etc.)
-
-x `PinStatus.meta[receivers] = ['multiaddr1','multiaddr2']`: A list of peers to which the user can connect in order to speed up transfer of pinned data
-
-x `Pin.meta[replication]`: This attribute could define how many copies a pinning service should keep
-
-x `Pin.meta[providers] = ['multiaddr1','multiaddr2']`: A list of peers that are known to have pinned data
-
+<ul>
+<li>`PinStatus.meta[progress]`&#x3a; Progress (as percent value) of an ongoing pinning operation, if possible to tell</li>
+<li>`PinStatus.meta[fail_reason]`&#x3a; A service-specific reason why a pin operation failed (e.g. lack of funds, DAG too big, etc.)</li>
+<li>`PinStatus.meta[receivers] = ['multiaddr1','multiaddr2']`&#x3a; A list of peers to which the user can connect in order to speed up transfer of pinned data</li>
+<li>`Pin.meta[replication]`&#x3a; This attribute could define how many copies a pinning service should keep</li>
+<li>`Pin.meta[providers] = ['multiaddr1','multiaddr2']`&#x3a; A list of peers that are known to have pinned data</li>
+</ul>
 
 While these attributes can be vendor-specific, we encourage the community at large to leverage these `meta` attributes as a sandbox to come up with conventions that could become part of future revisions of this API. 
 
 # Authorization
 
-An opaque authorization token is required to be sent with each request. There are two ways of doing so:
+An opaque authorization token is required to be sent with each request. There are two ways of doing so&#x3a;
 
-1 Using an HTTP header: `Authorization: Bearer <auth>`
-
-2 Using a query parameter: `&auth=<auth>`
+<ol>
+<li>Using an HTTP header&#x3a; `Authorization: Bearer <auth>`</li>
+<li>Using a query parameter&#x3a; `&auth=<auth>`</li>
+</ol>
 "
 
 servers:

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -13,7 +13,7 @@ info:
 <p>Your input and feedback are welcome and valuable as we develop this API spec. Please join the design discussion at github.com/ipfs/pinning-services-api-spec.</p>
 <h1>The pin object lifecycle</h1>
 <h2>Creating a new pin object</h2>
-<p>The user creates a pin object via <code>POST /pins</code> and receives a `PinStatus` response&#x3a;</p>
+<p>The user creates a pin object via <code>POST /pins</code> and receives a <code>PinStatus</code> response&#x3a;</p>
 <ul>
 <li><code>id</code> in <code>PinStatus</code> is <code>cid-of-pin-object</code>, which can can be used for modifying and/or removing the pin in the future</li>
 <li><code>status</code> in <code>PinStatus</code> indicates the current state of a pin</li>

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -9,11 +9,11 @@ info:
 <li>For use and implementation by pinning service providers</li>
 <li>For use in client mode by IPFS nodes and GUI-based applications</li>
 </ul>
-<h3>This spec is a work in progress! 🏗️</h3>
-<p>Your input and feedback are welcome and valuable as we develop this API spec. Please join the design discussion at <a href="https://github.com/ipfs/pinning-services-api-spec" target="_blank">https://github.com/ipfs/pinning-services-api-spec</a>.</p>
+<h3>This spec is a work in progress!</h3>
+<p>Your input and feedback are welcome and valuable as we develop this API spec. Please join the design discussion at github.com/ipfs/pinning-services-api-spec.</p>
 <h1>The pin object lifecycle</h1>
 <h2>Creating a new pin object</h2>
-<p>The user creates a pin object via `POST /pins` and receives a `PinStatus` response&#x3a;</p>
+<p>The user creates a pin object via <code>POST /pins</code> and receives a `PinStatus` response&#x3a;</p>
 <ul>
 <li><code>id</code> in <code>PinStatus</code> is <code>cid-of-pin-object</code>, which can can be used for modifying and/or removing the pin in the future</li>
 <li><code>status</code> in <code>PinStatus</code> indicates the current state of a pin</li>

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -10,7 +10,7 @@ info:
 <li>For use in client mode by IPFS nodes and GUI-based applications</li>
 </ul>
 <h3>This spec is a work in progress! &#127959;</h3>
-<p>Your input and feedback are welcome and valuable as we develop this API spec. Please join the design discussion at github.com/ipfs/pinning-services-api-spec.</p>
+<p><strong>Your input and feedback are welcome and valuable as we develop this API spec. Please join the design discussion at <a href=\"github.com/ipfs/pinning-services-api-spec\">github.com/ipfs/pinning-services-api-spec</a>.</strong></p>
 <h1>The pin object lifecycle</h1>
 <h2>Creating a new pin object</h2>
 <p>The user creates a pin object via <code>POST /pins</code> and receives a <code>PinStatus</code> response&#x3a;</p>

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -21,8 +21,10 @@ Your input and feedback are welcome and valuable as we develop this API spec. Pl
 
 The user creates a pin object via `POST /pins` and receives a `PinStatus` response&#x3a;
 
-- `id` in `PinStatus` is `cid-of-pin-object`, which can can be used for modifying and/or removing the pin in the future
-- `status` in  `PinStatus` indicates the current state of a pin
+<ul>
+<li><code>`id`</code> in <code>`PinStatus`</code> is <code>`cid-of-pin-object`</code>, which can can be used for modifying and/or removing the pin in the future</li>
+<li><code>`status`</code> in <code>`PinStatus`</code> indicates the current state of a pin</li>
+</ul>
 
 ### Checking status of in-progress pinning
 

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -6,6 +6,7 @@ info:
   
   
 # Overview
+
 The IPFS Pinning Service API is intended to be an implementation-agnostic API&#x3a;
 
 - For use and implementation by pinning service providers

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -3,71 +3,43 @@ info:
   version: "0.0.2"
   title: '(WIP) IPFS Pinning Service API'
   description: "
-# About this API
-
-The IPFS Pinning Service API is intended to be an implementation-agnostic API&#x3a;
+<h1>Overview</h1>
+<p>The IPFS Pinning Service API is intended to be an implementation-agnostic API&#x3a;</p>
 <ul>
 <li>For use and implementation by pinning service providers</li>
 <li>For use in client mode by IPFS nodes and GUI-based applications</li>
 </ul>
-
-### This spec is a work in progress! 🏗️
-
-Your input and feedback are welcome and valuable as we develop this API spec. Please join the design discussion at [https://github.com/ipfs/pinning-services-api-spec](https://github.com/ipfs/pinning-services-api-spec).
-
-# The pin object lifecycle
-
-## Creating a new pin object
-
-The user creates a pin object via `POST /pins` and receives a `PinStatus` response&#x3a;
-
+<h3>This spec is a work in progress! 🏗️</h3>
+<p>Your input and feedback are welcome and valuable as we develop this API spec. Please join the design discussion at <a href="https://github.com/ipfs/pinning-services-api-spec" target="_blank">https://github.com/ipfs/pinning-services-api-spec</a>.</p>
+<h1>The pin object lifecycle</h1>
+<h2>Creating a new pin object</h2>
+<p>The user creates a pin object via `POST /pins` and receives a `PinStatus` response&#x3a;</p>
 <ul>
-<li><code>`id`</code> in <code>`PinStatus`</code> is <code>`cid-of-pin-object`</code>, which can can be used for modifying and/or removing the pin in the future</li>
-<li><code>`status`</code> in <code>`PinStatus`</code> indicates the current state of a pin</li>
+<li><code>id</code> in <code>PinStatus</code> is <code>cid-of-pin-object</code>, which can can be used for modifying and/or removing the pin in the future</li>
+<li><code>status</code> in <code>PinStatus</code> indicates the current state of a pin</li>
 </ul>
-
-### Checking status of in-progress pinning
-
-`status` (in `PinStatus`) may indicate a pending state. This means the data
-behind `Pin.cid` was not found on the pinning service and is being fetched from the
-IPFS network at large, which may take time.
-
-In this case, the user can periodically check pinning progress via `GET
-/pins/{cid-of-pin-object}` until pinning is successful, or the user decides to remove
-the pending pin.
-
-## Modifying an existing pin object
-
-The user can modify an existing pin object via `POST
-/pins/{cid-of-pin-object}`. The new pin object `id` is returned in the `PinStatus`
-response. The old pin object is deleted automatically.
-
-## Removing a pin object
-
-A pin object can be removed via `DELETE /pins/{cid-of-pin-object}`.
-
-# Custom metadata
-
-Pinning services are encouraged to add support for additional features by leveraging the following optional `meta` attributes. Note that it is OK to ommit or ignore `meta` attributes;  
-doing so should not impact the basic pinning functionality.  
-
+<h3>Checking status of in-progress pinning</h3>
+<p><code>status</code> (in <code>PinStatus</code>) may indicate a pending state. This means the data behind <code>Pin.cid</code> was not found on the pinning service and is being fetched from the IPFS network at large, which may take time.</p>
+<p>In this case, the user can periodically check pinning progress via <code>GET /pins/{cid-of-pin-object}</code> until pinning is successful, or the user decides to remove the pending pin.</p>
+<h2>Modifying an existing pin object</h2>
+<p>The user can modify an existing pin object via <code>POST /pins/{cid-of-pin-object}</code>. The new pin object <code>id</code> is returned in the <code>PinStatus</code> response. The old pin object is deleted automatically.</p>
+<h2>Removing a pin object</h2>
+<p>A pin object can be removed via <code>DELETE /pins/{cid-of-pin-object}</code>.</p>
+<h1>Custom metadata</h1>
+<p>Pinning services are encouraged to add support for additional features by leveraging the following optional <code>meta</code> attributes. Note that it is OK to ommit or ignore <code>meta</code> attributes; doing so should not impact the basic pinning functionality.</p>
 <ul>
-<li>`PinStatus.meta[progress]`&#x3a; Progress (as percent value) of an ongoing pinning operation, if possible to tell</li>
-<li>`PinStatus.meta[fail_reason]`&#x3a; A service-specific reason why a pin operation failed (e.g. lack of funds, DAG too big, etc.)</li>
-<li>`PinStatus.meta[receivers] = ['multiaddr1','multiaddr2']`&#x3a; A list of peers to which the user can connect in order to speed up transfer of pinned data</li>
-<li>`Pin.meta[replication]`&#x3a; This attribute could define how many copies a pinning service should keep</li>
-<li>`Pin.meta[providers] = ['multiaddr1','multiaddr2']`&#x3a; A list of peers that are known to have pinned data</li>
+<li><code>PinStatus.meta[progress]</code>&#x3a; Progress (as percent value) of an ongoing pinning operation, if possible to tell</li>
+<li><code>PinStatus.meta[fail_reason]</code>&#x3a; A service-specific reason why a pin operation failed (e.g. lack of funds, DAG too big, etc.)</li>
+<li><code>PinStatus.meta[receivers] = ['multiaddr1','multiaddr2']</code>&#x3a; A list of peers to which the user can connect in order to speed up transfer of pinned data</li>
+<li><code>Pin.meta[replication]</code>&#x3a; This attribute could define how many copies a pinning service should keep</li>
+<li><code>Pin.meta[providers] = ['multiaddr1','multiaddr2']<,code>&#x3a; A list of peers that are known to have pinned data</li>
 </ul>
-
-While these attributes can be vendor-specific, we encourage the community at large to leverage these `meta` attributes as a sandbox to come up with conventions that could become part of future revisions of this API. 
-
-# Authorization
-
-An opaque authorization token is required to be sent with each request. There are two ways of doing so&#x3a;
-
+<p>While these attributes can be vendor-specific, we encourage the community at large to leverage these <code>meta</code> attributes as a sandbox to come up with conventions that could become part of future revisions of this API.</p> 
+<h1>Authorization</h1>
+<p>An opaque authorization token is required to be sent with each request. There are two ways of doing so&#x3a;</p>
 <ol>
-<li>Using an HTTP header&#x3a; `Authorization: Bearer <auth>`</li>
-<li>Using a query parameter&#x3a; `&auth=<auth>`</li>
+<li>Using an HTTP header&#x3a; <code>Authorization&#x3a; Bearer <auth></code></li>
+<li>Using a query parameter&#x3a; <code>&auth=<auth></code></li>
 </ol>
 "
 

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -10,6 +10,7 @@ info:
 The IPFS Pinning Service API is intended to be an implementation-agnostic API&#x3a;
 
 - For use and implementation by pinning service providers
+
 - For use in client mode by IPFS nodes and GUI-based applications
 
 

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -21,10 +21,8 @@ Your input and feedback are welcome and valuable as we develop this API spec. Pl
 
 The user creates a pin object via `POST /pins` and receives a `PinStatus` response&#x3a;
 
-<ul>
-<li>`id` in `PinStatus` is `cid-of-pin-object`, which can can be used for modifying and/or removing the pin in the future</li>
-<li>`status` in  `PinStatus` indicates the current state of a pin</li>
-</ul>
+- `id` in `PinStatus` is `cid-of-pin-object`, which can can be used for modifying and/or removing the pin in the future
+- `status` in  `PinStatus` indicates the current state of a pin
 
 ### Checking status of in-progress pinning
 

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -3,78 +3,74 @@ info:
   version: "0.0.2"
   title: '(WIP) IPFS Pinning Service API'
   description: "
-# About
+# About this API
 
-This is the IPFS Pinning Service API. It attempts to be an
-implementation-agnostic API designed to be implemented by Pinning Service
-Providers and used in client mode by IPFS nodes and GUI applications.
+The IPFS Pinning Service API is intended to be an implementation-agnostic API: 
 
-## THIS SPEC IS WORK IN PROGRESS 🏗️
+- For use and implementation by pinning service providers 
+- For use in client mode by IPFS nodes and GUI-based applications
 
-Join design discussion at  [https://github.com/ipfs/pinning-services-api-spec](https://github.com/ipfs/pinning-services-api-spec)
+### This spec is a work in progress! 🏗️
 
-# Pin object lifecycle
+Your input and feedback are welcome and valuable as we develop this API spec. Please join the design discussion at [https://github.com/ipfs/pinning-services-api-spec](https://github.com/ipfs/pinning-services-api-spec).
 
-## Creating a new pin
+# The pin object lifecycle
 
-User creates pin object via `POST /pins` and receives `PinStatus` response
+## Creating a new pin object
 
-- `id` in `PinStatus` is `cid-of-pin-object` that can be used for modifying
-  and removing pin in the future
+The user creates a pin object via `POST /pins` and receives a `PinStatus` response:
 
-- `status` in  `PinStatus` indicates current state of a pin
+- `id` in `PinStatus` is `cid-of-pin-object`, which can can be used for modifying
+  and/or removing the pin in the future
+
+- `status` in  `PinStatus` indicates the current state of a pin
 
 
-### Checking status of pinning in progress
+### Checking status of in-progress pinning
 
-`status` from `PinStatus` may indicate a pending state. It means the data
-behind `Pin.cid` was not found on pinning service and is being fetched from
-IPFS network, which may take time.
+`status` (in `PinStatus`) may indicate a pending state. This means the data
+behind `Pin.cid` was not found on the pinning service and is being fetched from the
+IPFS network at large, which may take time.
 
-In that case, user can periodically check pinning progress via `GET
-/pins/{cid-of-pin-object}`, until pinning is successful, or decides to remove
-pending pin.
+In this case, the user can periodically check pinning progress via `GET
+/pins/{cid-of-pin-object}` until pinning is successful, or the user decides to remove
+the pending pin.
 
-## Modifying existing pin object
+## Modifying an existing pin object
 
-User may decide to modify existing pin object via `POST
-/pins/{cid-of-pin-object}`. The new pin object `id` is returned in `PinStatus`
+The user can modify an existing pin object via `POST
+/pins/{cid-of-pin-object}`. The new pin object `id` is returned in the `PinStatus`
 response. The old pin object is deleted automatically.
 
 ## Removing a pin object
 
-Pin object can be removed via `DELETE /pins/{cid-of-pin-object}`
+A pin object can be removed via `DELETE /pins/{cid-of-pin-object}`.
 
 # Custom metadata
 
-Pinning Services are encouraged to add support for additional features by
-leveraging optional `meta` attributes:
+Pinning services are encouraged to add support for additional features by leveraging the following optional `meta` attributes. Note that it is OK to ommit or ignore `meta` attributes;  
+doing so should not impact the basic pinning functionality.  
 
-- `PinStatus.meta[progress]` –  % progress of ongoing pinning operation (if possible to tell)
+- `PinStatus.meta[progress]`: Progress (as percent value) of an ongoing pinning operation, if possible to tell
 
-- `PinStatus.meta[fail_reason]` - service-specific reason why pin operation failed (eg. lack of funds, DAG too big etc)
+- `PinStatus.meta[fail_reason]`: A service-specific reason why a pin operation failed (e.g. lack of funds, DAG too big, etc.)
 
-- `PinStatus.meta[receivers] = ['multiaddr1','multiaddr2']` list of peers to connect to to speed up transfer of pinned data
+- `PinStatus.meta[receivers] = ['multiaddr1','multiaddr2']`: A list of peers to which the user can connect in order to speed up transfer of pinned data
 
-- `Pin.meta[replication]` – could define how many copies service should keep
+- `Pin.meta[replication]`: This attribute could define how many copies a pinning service should keep
 
-- `Pin.meta[providers] = ['multiaddr1','multiaddr2']` list of peers that are known to have pinned data
+- `Pin.meta[providers] = ['multiaddr1','multiaddr2']`: A list of peers that are known to have pinned data
 
-Those can be vendor-specific, but we encourage community to leverage `meta` to
-come up with conventions that could become part of future revisions of this
-API. 
 
-It is ok to ommit or ignore `meta` attributes.  
-Doing so should not impact the basic pinning functionality.  
+While these attributes can be vendor-specific, we encourage the community at large to leverage these `meta` attributes as a sandbox to come up with conventions that could become part of future revisions of this API. 
 
 # Authorization
 
-An opaque auth token is required to be sent with each request.
-There are two ways of doing so:
+An opaque authorization token is required to be sent with each request. There are two ways of doing so:
 
-- HTTP header: `Authorization: Bearer <auth>`
+1. Using an HTTP header: `Authorization: Bearer <auth>`
 
-- query parameter: `&auth=<auth>`
+2. Using a query parameter: `&auth=<auth>`
 "
 
 servers:
@@ -84,7 +80,7 @@ paths:
   /pins:
     get:
       summary: List pin objects
-      description: List all the pin objects and status matching optional parameters
+      description: List all the pin objects and their status, matching optional parameters.
       tags:
         - pins
       parameters:
@@ -108,7 +104,7 @@ paths:
           $ref: '#/components/responses/InternalServerError'
     post:
       summary: Add an array of pin objects
-      description: Add an array of pin objects for the current user
+      description: Add an array of pin objects for the current user.
       tags:
         - pins
       parameters:
@@ -151,7 +147,7 @@ paths:
       - $ref: '#/components/parameters/auth'
     get:
       summary: Get pin object
-      description: Get pin object with status
+      description: Get a pin object and its status.
       tags:
         - pins
       parameters:
@@ -171,7 +167,7 @@ paths:
           $ref: '#/components/responses/InternalServerError'
     post:
       summary: Modify pin object
-      description: Modifies existing pin object
+      description: Modify an existing pin object.
       tags:
         - pins
       parameters:
@@ -203,7 +199,7 @@ paths:
           $ref: '#/components/responses/InternalServerError'
     delete:
       summary: Remove pin object
-      description: Remove pin object
+      description: Remove a pin object.
       tags:
         - pins
       parameters:
@@ -224,7 +220,7 @@ components:
   schemas:
 
     PinStatus:
-      description: Pin object with Status
+      description: pin object with status
       type: object
       required:
         - id
@@ -232,7 +228,7 @@ components:
         - pin
       properties:
         id:
-          description: CID of Pin object that can be used for status checks of ongoing pinning
+          description: CID of pin object; can be used to check status of ongoing pinning
           type: string
         status:
           $ref: '#/components/schemas/Status'
@@ -242,7 +238,7 @@ components:
           $ref: '#/components/schemas/Meta'
 
     Pin:
-      description: Pin object
+      description: pin object
       type: object
       required:
         - cid
@@ -254,24 +250,24 @@ components:
           $ref: '#/components/schemas/Meta'
 
     Status:
-      description: Status in which pin object can exist at a pinning service
+      description: status a pin object can have at a pinning service
       type: string
       enum:
-        - resolving  # pinning in-progress: verifying pin request and looking for providers
-        - retrieving # pinning in-progress: connected to at least one provider and fetched at least one block
+        - resolving  # pinning in progress: verifying pin request and looking for providers
+        - retrieving # pinning in progress: connected to at least one provider and fetched at least one block
         - pinned     # pinned successfully
-        - failed     # pining service was unable to finish pinning operation, details can be found in meta[fail_reason]
-        - expired    # (optional) still pinned for some time, but run out of funds and won't be provided to the IPFS network
-        - unpinning  # (optional) unpinning in-progress
+        - failed     # pining service was unable to finish pinning operation; details can be found in meta[fail_reason]
+        - expired    # (optional) still pinned for some time, but ran out of funds and won't be provided to the IPFS network
+        - unpinning  # (optional) unpinning in progress
 
     Meta:
-      description: Optional metadata
+      description: optional metadata
       type: object
       additionalProperties:
         type: string
 
     Error:
-      description: Base Error object
+      description: base error object
       type: object
       required:
         - code
@@ -319,14 +315,14 @@ components:
       explode: false
       examples:
         oneId:
-          summary: Example of a single CID
+          summary: example of a single CID
           value: [QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR]   # ?cid=Qm
         multipleIds:
-          summary: Example of multiple CIDs
+          summary: example of multiple CIDs
           value: [QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR,bafkreigtdgsgv2f3bkhsmxvku3bpnnqzubcxeupf7fff5f7l7tlm2v237a]   # ?cid=Qm,bafy
 
     status:
-      description: return pin objects for pins in the specified status
+      description: return pin objects for pins with the specified status
       name: status
       in: query
       required: false
@@ -347,7 +343,7 @@ components:
 
   responses:
     BadRequest:
-      description: Bad Request (400)
+      description: Bad request (400)
       content:
         application/json:
           schema:
@@ -368,14 +364,14 @@ components:
             $ref: '#/components/schemas/Error'
 
     InsufficientFunds:
-      description: Insufficient Funds (409)
+      description: Insufficient funds (409)
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/Error'
 
     InternalServerError:
-      description: Internal Server Error (500)
+      description: Internal server error (500)
       content:
         application/json:
           schema:

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -10,7 +10,7 @@ info:
 <li>For use in client mode by IPFS nodes and GUI-based applications</li>
 </ul>
 <h3>This spec is a work in progress! &#127959;</h3>
-<p><strong>Your input and feedback are welcome and valuable as we develop this API spec. Please join the design discussion at <a href=\"github.com/ipfs/pinning-services-api-spec\">github.com/ipfs/pinning-services-api-spec</a>.</strong></p>
+<p><strong>Your input and feedback are welcome and valuable as we develop this API spec. Please join the design discussion at <a href=\"https://github.com/ipfs/pinning-services-api-spec\">github.com/ipfs/pinning-services-api-spec</a>.</strong></p>
 <h1>The pin object lifecycle</h1>
 <h2>Creating a new pin object</h2>
 <p>The user creates a pin object via <code>POST /pins</code> and receives a <code>PinStatus</code> response&#x3a;</p>

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -9,7 +9,7 @@ info:
 <li>For use and implementation by pinning service providers</li>
 <li>For use in client mode by IPFS nodes and GUI-based applications</li>
 </ul>
-<h3>This spec is a work in progress!</h3>
+<h3>This spec is a work in progress! &#127959;</h3>
 <p>Your input and feedback are welcome and valuable as we develop this API spec. Please join the design discussion at github.com/ipfs/pinning-services-api-spec.</p>
 <h1>The pin object lifecycle</h1>
 <h2>Creating a new pin object</h2>

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -10,7 +10,7 @@ info:
 <li>For use in client mode by IPFS nodes and GUI-based applications</li>
 </ul>
 <h3>This spec is a work in progress! &#127959;</h3>
-<p><strong>Your input and feedback are welcome and valuable as we develop this API spec. Please join the design discussion at <a href=\"https://github.com/ipfs/pinning-services-api-spec\">github.com/ipfs/pinning-services-api-spec</a>.</strong></p>
+<p><strong>Your input and feedback are welcome and valuable as we develop this API spec. Please join the design discussion at <a href=\"https://github.com/ipfs/pinning-services-api-spec\" target=\"_blank\">github.com/ipfs/pinning-services-api-spec</a>.</strong></p>
 <h1>The pin object lifecycle</h1>
 <h2>Creating a new pin object</h2>
 <p>The user creates a pin object via <code>POST /pins</code> and receives a <code>PinStatus</code> response&#x3a;</p>


### PR DESCRIPTION
As discussed out-of-band, copy edits throughout for consistency of language and capitalization. 

Also rewrote introductory section as explicit HTML (escaping out double quotes as needed) so markdown formatting cues didn't get interpreted as random bits of YAML.