### PR TITLE
Make inline code color in intro material consistent with IPFS docs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -14,6 +14,7 @@
     --code-fg: #ffffff;
     --font-size-mono: 14px;
     --green: #0cb892;
+    --inline-code-fg: #676c78;
     --placeholder-color: #b7bbc8;
     --red: #ea5037;
     --selection-bg: #edf0f4;


### PR DESCRIPTION
Adding inline code to the API docs' introductory material revealed an additional inconsistency with IPFS docs: should be charcoal, not that weird brown-red.