### PR TITLE
Remove unpinned status

### DIFF
--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -307,7 +307,6 @@ components:
         - pinning    # pinning in progress, optional details can be returned in meta[pinning_status]
         - pinned     # pinned successfully
         - failed     # pining service was unable to finish pinning operation, optional details can be found in meta[fail_reason]
-        - unpinned   # data is no longer pinned
 
     ServiceProviders:
       description: list of multiaddrs designated by pinning service for transferring any new data from external peers


### PR DESCRIPTION
This PR removes `unpinned` from `Status` enum.

### Rationale

There is no way to end up in "unpinned" state when using this API other than removing a pin object. 
This implies pinning service is required to keep a history of all past pins in case user wants to bring them back. 

After internal reviews this status does not make sense for MVP, is not useful for integration with IPFS Desktop/WebUI
If user wants to bring back old Pin (eg. due to its metadata), they can read it before unpinning, persist it off-band and then add a new Pin in the future.

cc @obo20