### PR TITLE
Add queued status, restore status array filter

### DIFF
--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -304,9 +304,10 @@ components:
       description: status a pin object can have at a pinning service
       type: string
       enum:
-        - pinning    # pinning in progress, optional details can be returned in meta[pinning_status]
+        - queued     # pinning operation is waiting in the queue, additional info can be returned in meta[status_details]      
+        - pinning    # pinning in progress, additional info can be returned in meta[status_details]
         - pinned     # pinned successfully
-        - failed     # pining service was unable to finish pinning operation, optional details can be found in meta[fail_reason]
+        - failed     # pining service was unable to finish pinning operation, additional info can be found in meta[status_details]
         - unpinned   # data is no longer pinned
 
     ServiceProviders:
@@ -397,7 +398,13 @@ components:
       in: query
       required: false
       schema:
-        $ref: '#/components/schemas/Status'
+        type: array
+        items:
+          $ref: '#/components/schemas/Status'
+        uniqueItems: true
+        minItems: 1
+      style: form # ?status=queued,pinning
+      explode: false
 
     auth:
       description: optional auth token (alternative to Authorization header)


### PR DESCRIPTION
This adds `queued` status for indicating scheduled pinning operations that did not start yet.

It is based on feedback from IPFS Cluster (cc @lanzafame) which suggested we should make it very clear when pinning is actively happening, and when it is pending due to service load etc. People coming to distributed systems should have better insight into what is happening, and where the delay comes from.

Because this introduces second "pinning-in-progress" status,
we restore `status` parameter to accept multiple states.

cc @obo20 for visibility, as this partially reverts #28 and brings filtering over multiple states back