### PR TITLE
Add context diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 > This repository contains the specs for the vendor-agnostic pinning service API for the IPFS ecosystem
 
+![pinning-services-api-contex.png](https://bafkreibw7a6pq7zq4ljtpwdegzr5bru653q6uevzvq65pq6pqrjorxpkli.ipfs.dweb.link/?filename=pinning-services-api-contex.png)
+
 - [About](#about)
 - [Specification](#specification)
 - [Adoption](#adoption)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 > This repository contains the specs for the vendor-agnostic pinning service API for the IPFS ecosystem
 
-![pinning-services-api-contex.png](https://bafkreibw7a6pq7zq4ljtpwdegzr5bru653q6uevzvq65pq6pqrjorxpkli.ipfs.dweb.link/?filename=pinning-services-api-contex.png)
+[![pinning-services-api-contex.png](https://bafkreibw7a6pq7zq4ljtpwdegzr5bru653q6uevzvq65pq6pqrjorxpkli.ipfs.dweb.link/?filename=pinning-services-api-contex.png)](#about)
 
 - [About](#about)
 - [Specification](#specification)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 > This repository contains the specs for the vendor-agnostic pinning service API for the IPFS ecosystem
 
-[![pinning-services-api-contex.png](https://bafkreibw7a6pq7zq4ljtpwdegzr5bru653q6uevzvq65pq6pqrjorxpkli.ipfs.dweb.link/?filename=pinning-services-api-contex.png)](#about)
+[![pinning-services-api-contex.png](https://bafkreiffr3aebionzn4c3j7awih5erdwdlvrtjpdl4i3awyasslaaqpx2e.ipfs.dweb.link/?filename=pinning-services-api-contex.png)](#about)
 
 - [About](#about)
 - [Specification](#specification)

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -50,6 +50,9 @@ It includes the original `pin` object, along with current `status` and `id`, whi
 ## The pin lifecycle
 
 
+![pinning-services-api-objects.png](https://bafkreidoahwczlxww2y4d7d56cojpsuredfprtodzfzzadasbeyg7zftr4.ipfs.dweb.link/?filename=pinning-services-api-objects.png)
+
+
 ### Creating a new pin object
 
 The user sends one or more `Pin` objects via `POST /pins` and receives `PinStatus` response for each:


### PR DESCRIPTION
This PR adds the context diagram suggested by Pooja as the very first thing in the README.

Preview: 

- https://github.com/ipfs/pinning-services-api-spec/blob/docs/context-diagram/README.md#pinning-service-api-spec


Ref. https://www.figma.com/file/nTnNpsj68kT1dI7WXyQ2QS/Pinning-Service-Core

cc @pooja @eshon @jessicaschilling 