### PR TITLE
fix: single pin I/O in POST operations

### DIFF
--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -181,7 +181,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PinResults'
+                $ref: '#/components/schemas/PinStatus'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -228,9 +228,7 @@ paths:
         content:
           application/json:
             schema:
-              type: array
-              items:
-                $ref: '#/components/schemas/Pin'
+              $ref: '#/components/schemas/Pin'
       responses:
         '202':
           description: Accepted


### PR DESCRIPTION
This PR removes arrays and replaces them with single object in places which were missed before when we made the switch to single ops – context: https://github.com/ipfs/pinning-services-api-spec/pull/39#issuecomment-665274030

Preview: https://ipfs.github.io/pinning-services-api-spec/#specUrl=https://raw.githubusercontent.com/ipfs/pinning-services-api-spec/fix/single-pin-ops-everywhere/ipfs-pinning-service.yaml

Closes #46 cc @obo20 