### PR TITLE
fix: disambiguating *.providers fields

### DIFF
--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -33,7 +33,7 @@ A full list of fields and schemas can be found in the `schemas` section of the [
 The `Pin` object is a representation of a pin request.
 
 
-It includes the `cid` of data to be pinned, as well as optional metadata in `providers` and `meta`.
+It includes the `cid` of data to be pinned, as well as optional metadata in `origins` and `meta`.
 
 
 ### Pin status object
@@ -80,13 +80,13 @@ A pin object can be removed via `DELETE /pins/{cid-of-pin-object}`.
 ## Provider hints
 
 Pinning of new data can be accelerated by providing a list of known data
-sources in `Pin.providers`, and connecting at least one of them to pinning
-service nodes at `PinStatus.providers`.
+sources in `Pin.origins`, and connecting at least one of them to pinning
+service nodes at `PinStatus.delegates`.
 
 
 The most common scenario is a client putting its own IPFS node's multiaddrs in
-`Pin.providers`,  and then directly connecting to every multiaddr returned by
-a pinning service in `PinStatus.providers` to initiate transfer.
+`Pin.origins`,  and then directly connecting to every multiaddr returned by
+a pinning service in `PinStatus.delegates` to initiate transfer.
 
 
 This ensures data transfer starts immediately (without waiting for provider
@@ -297,7 +297,7 @@ components:
         - status
         - created
         - pin
-        - providers
+        - delegates
       properties:
         id:
           description: CID of pin object; can be used to check status of ongoing pinning
@@ -312,8 +312,8 @@ components:
           example: "2020-07-27T17:32:28Z"
         pin:
           $ref: '#/components/schemas/Pin'
-        providers:
-          $ref: '#/components/schemas/ServiceProviders'
+        delegates:
+          $ref: '#/components/schemas/Delegates'
         meta:
           $ref: '#/components/schemas/StatusMeta'
 
@@ -327,8 +327,8 @@ components:
           description: CID to be pinned recursively
           type: string
           example: "QmCIDToBePinned"
-        providers:
-          $ref: '#/components/schemas/DataProviders'
+        origins:
+          $ref: '#/components/schemas/Origins'
         meta:
           $ref: '#/components/schemas/PinMeta'
 
@@ -341,7 +341,7 @@ components:
         - pinned     # pinned successfully
         - failed     # pinning service was unable to finish pinning operation; additional info can be found in meta[status_details]
 
-    ServiceProviders:
+    Delegates:
       description: List of multiaddrs designated by pinning service for transferring any new data from external peers
       type: array
       items:
@@ -351,7 +351,7 @@ components:
       maxItems: 20
       example: ['/dnsaddr/pin-service.example.com']
 
-    DataProviders:
+    Origins:
       description: Optional list of multiaddrs known to provide the data
       type: array
       items:


### PR DESCRIPTION
Renaming according to poll results:

![Screenshot_2020-08-13 How should we (re)name Pin providers ](https://user-images.githubusercontent.com/157609/90142002-22ef1b00-dd7c-11ea-96ca-be21383954e3.png)

![Screenshot_2020-08-13 How should we (re)name PinStatus providers ](https://user-images.githubusercontent.com/157609/90141997-22568480-dd7c-11ea-8500-d12116276055.png)

Closes #41