### PR TITLE
docs: query params examples

### DIFF
--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -481,13 +481,7 @@ components:
         maxItems: 1000
       style: form # ?cid=Qm1,Qm2,bafy3
       explode: false
-      examples:
-        oneId:
-          summary: Example of a single CID
-          value: [QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR]   # ?cid=Qm
-        multipleIds:
-          summary: Example of multiple CIDs
-          value: [QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR,bafkreigtdgsgv2f3bkhsmxvku3bpnnqzubcxeupf7fff5f7l7tlm2v237a]   # ?cid=Qm,bafy
+      example: ["Qm1","Qm2","bafy3"]
 
     name:
       description: Return pin objects with names that contain provided value (partial or full match)
@@ -512,6 +506,7 @@ components:
         minItems: 1
       style: form # ?status=queued,pinning
       explode: false
+      example: ["queued","pinning"]
 
     meta:
       description: Return pin objects that match specified metadata


### PR DESCRIPTION
This PR fixes examples generated from YAML. 
Docs now include inlined examples of how arrays should be passed in each query param:

> ![2020-08-26--17-20-51](https://user-images.githubusercontent.com/157609/91323130-d4e90700-e7c0-11ea-930e-cd8ecb2aecfb.png)




Preview: https://ipfs.github.io/pinning-services-api-spec/#specUrl=https://raw.githubusercontent.com/ipfs/pinning-services-api-spec/docs/query-param-examples/ipfs-pinning-service.yaml

Closes #54 cc @andrew @obo20 