### PR TITLE
docs: case-insensitive Pin.name filter

### DIFF
--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -484,7 +484,7 @@ components:
       example: ["Qm1","Qm2","bafy3"]
 
     name:
-      description: Return pin objects with names that contain provided value (partial or full match)
+      description: Return pin objects with names that contain provided value (case-sensitive, partial or full match)
       name: name
       in: query
       required: false

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -484,7 +484,7 @@ components:
       example: ["Qm1","Qm2","bafy3"]
 
     name:
-      description: Return pin objects with names that contain provided value (case-sensitive, partial or full match)
+      description: Return pin objects with names that contain provided value (case-insensitive, partial or full match)
       name: name
       in: query
       required: false


### PR DESCRIPTION
This PR updates description of `name` filter and removes ambiguity, as noted in https://github.com/ipfs/pinning-services-api-spec/issues/45#issuecomment-682608214 by @andrew and @obo20 

The rationale for going with case-sensitive is that it is more performance out of the box, does not require any additional indexes or optimizations, and one can use third-party case-sensitive identifiers (other than CID).

Case-insensitive makes it easier to search and returns not false-negatives, but comes with a risk for bugs when a search results in table scan even when there is an index on the name column.

Let's review which way to go in this PR.

**Update:** we went with case-insensitive