### PR TITLE
feat: improved error responses

### DIFF
--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -197,7 +197,15 @@ paths:
               schema:
                 $ref: '#/components/schemas/PinResults'
         '400':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/InsufficientFunds'
+        '5XX':
+          $ref: '#/components/responses/InternalServerError'
     post:
       summary: Add pin object
       description: Add a new pin object for the current access token
@@ -217,7 +225,15 @@ paths:
               schema:
                 $ref: '#/components/schemas/PinStatus'
         '400':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/InsufficientFunds'
+        '5XX':
+          $ref: '#/components/responses/InternalServerError'
 
   /pins/{id}:
     parameters:
@@ -239,7 +255,15 @@ paths:
               schema:
                 $ref: '#/components/schemas/PinStatus'
         '400':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/InsufficientFunds'
+        '5XX':
+          $ref: '#/components/responses/InternalServerError'
     post:
       summary: Modify pin object
       description: Modify an existing pin object
@@ -259,7 +283,15 @@ paths:
               schema:
                 $ref: '#/components/schemas/PinStatus'
         '400':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/InsufficientFunds'
+        '5XX':
+          $ref: '#/components/responses/InternalServerError'
     delete:
       summary: Remove pin object
       description: Remove a pin object
@@ -269,7 +301,15 @@ paths:
         '202':
           description: Successful response (no body, pin removed)
         '400':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/InsufficientFunds'
+        '5XX':
+          $ref: '#/components/responses/InternalServerError'
 
 components:
   schemas:
@@ -407,11 +447,11 @@ components:
             reason:
               type: string
               description: Mandatory string identifying the type of error
-              example: "INVALID_ACCESS_TOKEN"
+              example: "ERROR_CODE_FOR_MACHINES"
             details:
               type: string
               description: Optional, longer description of the error; may include UUID of transaction for support, links to documentation etc
-              example: "Unauthorized: access token is missing or invalid"
+              example: "Optional explanation for humans with more details"
 
   parameters:
 
@@ -499,12 +539,93 @@ components:
             $ref: '#/components/schemas/PinMeta'
 
   responses:
-    Error:
-      description: Error response
+
+    BadRequest:
+      description: Error response (Bad request)
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/Error'
+          examples:
+            BadRequestExample:
+              $ref: '#/components/examples/BadRequestExample'
+
+    Unauthorized:
+      description: Error response (Unauthorized; access token is missing or invalid)
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          examples:
+            UnauthorizedExample:
+              $ref: '#/components/examples/UnauthorizedExample'
+
+    NotFound:
+      description: Error response (The specified resource was not found)
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          examples:
+            NotFoundExample:
+              $ref: '#/components/examples/NotFoundExample'
+
+    InsufficientFunds:
+      description: Error response (Insufficient funds)
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          examples:
+            InsufficientFundsExample:
+              $ref: '#/components/examples/InsufficientFundsExample'
+
+    InternalServerError:
+      description: Error response (Unexpected internal server error)
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          examples:
+            InternalServerErrorExample:
+              $ref: '#/components/examples/InternalServerErrorExample'
+
+  examples:
+
+    BadRequestExample:
+      value:
+        error:
+          reason: "BAD_REQUEST"
+          details: "Explanation for humans with more details"
+      summary: A sample response to a bad request; reason will differ
+
+    UnauthorizedExample:
+      value:
+        error:
+          reason: "UNAUTHORIZED"
+          details: "Access token is missing or invalid"
+      summary: Response to an unauthorized request
+
+    NotFoundExample:
+      value:
+        error:
+          reason: "NOT_FOUND"
+          details: "The specified resource was not found"
+      summary: Response to a request for a resource that does not exist
+
+    InsufficientFundsExample:
+      value:
+        error:
+          reason: "INSUFFICIENT_FUNDS"
+          details: "Unable to process request due to the lack of funds"
+      summary: Response when access token run out of funds
+
+    InternalServerErrorExample:
+      value:
+        error:
+          reason: "INTERNAL_SERVER_ERROR"
+          details: "Explanation for humans with more details"
+      summary: Response when unexpected error occured
 
   securitySchemes:
     accessToken:

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -191,15 +191,13 @@ paths:
         - $ref: '#/components/parameters/meta'
       responses:
         '200':
-          description: OK
+          description: Successful response (PinResults object)
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/PinResults'
         '400':
-          $ref: '#/components/responses/BadRequest'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
+          $ref: '#/components/responses/Error'
     post:
       summary: Add pin object
       description: Add a new pin object for the current access token
@@ -213,21 +211,13 @@ paths:
               $ref: '#/components/schemas/Pin'
       responses:
         '202':
-          description: Accepted
+          description: Successful response (PinStatus object)
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/PinStatus'
         '400':
-          $ref: '#/components/responses/BadRequest'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '409':
-          $ref: '#/components/responses/InsufficientFunds'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
+          $ref: '#/components/responses/Error'
 
   /pins/{id}:
     parameters:
@@ -243,17 +233,13 @@ paths:
         - pins
       responses:
         '200':
-          description: OK
+          description: Successful response (PinStatus object)
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/PinStatus'
         '400':
-          $ref: '#/components/responses/BadRequest'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
+          $ref: '#/components/responses/Error'
     post:
       summary: Modify pin object
       description: Modify an existing pin object
@@ -267,21 +253,13 @@ paths:
               $ref: '#/components/schemas/Pin'
       responses:
         '202':
-          description: Accepted
+          description: Successful response (PinStatus object)
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/PinStatus'
         '400':
-          $ref: '#/components/responses/BadRequest'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '409':
-          $ref: '#/components/responses/InsufficientFunds'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
+          $ref: '#/components/responses/Error'
     delete:
       summary: Remove pin object
       description: Remove a pin object
@@ -289,15 +267,9 @@ paths:
         - pins
       responses:
         '202':
-          description: Accepted
+          description: Successful response (no body, pin removed)
         '400':
-          $ref: '#/components/responses/BadRequest'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
+          $ref: '#/components/responses/Error'
 
 components:
   schemas:
@@ -422,16 +394,24 @@ components:
         status_details: "Queue position: 7 of 9" # PinStatus.info[status_details], when status=queued
 
     Error:
-      description: Base error object
+      description: Error object
       type: object
       required:
-        - code
-        - message
+        - error
       properties:
-        code:
-          type: integer
-        message:
-          type: string
+        error:
+          type: object
+          required:
+            - reason
+          properties:
+            reason:
+              type: string
+              description: Mandatory string identifying the type of error
+              example: "INVALID_ACCESS_TOKEN"
+            details:
+              type: string
+              description: Optional, longer description of the error; may include UUID of transaction for support, links to documentation etc
+              example: "Unauthorized: access token is missing or invalid"
 
   parameters:
 
@@ -519,36 +499,8 @@ components:
             $ref: '#/components/schemas/PinMeta'
 
   responses:
-    BadRequest:
-      description: Bad request (400)
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/Error'
-
-    Unauthorized:
-      description: Unauthorized (401); access token is missing or invalid
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/Error'
-
-    NotFound:
-      description: The specified resource was not found (404)
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/Error'
-
-    InsufficientFunds:
-      description: Insufficient funds (409)
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/Error'
-
-    InternalServerError:
-      description: Internal server error (500)
+    Error:
+      description: Error response
       content:
         application/json:
           schema:

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -204,6 +204,8 @@ paths:
           $ref: '#/components/responses/NotFound'
         '409':
           $ref: '#/components/responses/InsufficientFunds'
+        '4XX':
+          $ref: '#/components/responses/CustomServiceError'
         '5XX':
           $ref: '#/components/responses/InternalServerError'
     post:
@@ -232,6 +234,8 @@ paths:
           $ref: '#/components/responses/NotFound'
         '409':
           $ref: '#/components/responses/InsufficientFunds'
+        '4XX':
+          $ref: '#/components/responses/CustomServiceError'
         '5XX':
           $ref: '#/components/responses/InternalServerError'
 
@@ -262,6 +266,8 @@ paths:
           $ref: '#/components/responses/NotFound'
         '409':
           $ref: '#/components/responses/InsufficientFunds'
+        '4XX':
+          $ref: '#/components/responses/CustomServiceError'
         '5XX':
           $ref: '#/components/responses/InternalServerError'
     post:
@@ -290,6 +296,8 @@ paths:
           $ref: '#/components/responses/NotFound'
         '409':
           $ref: '#/components/responses/InsufficientFunds'
+        '4XX':
+          $ref: '#/components/responses/CustomServiceError'
         '5XX':
           $ref: '#/components/responses/InternalServerError'
     delete:
@@ -308,6 +316,8 @@ paths:
           $ref: '#/components/responses/NotFound'
         '409':
           $ref: '#/components/responses/InsufficientFunds'
+        '4XX':
+          $ref: '#/components/responses/CustomServiceError'
         '5XX':
           $ref: '#/components/responses/InternalServerError'
 
@@ -580,6 +590,16 @@ components:
             InsufficientFundsExample:
               $ref: '#/components/examples/InsufficientFundsExample'
 
+    CustomServiceError:
+      description: Error response (Custom service error)
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          examples:
+            CustomServiceErrorExample:
+              $ref: '#/components/examples/CustomServiceErrorExample'
+
     InternalServerError:
       description: Error response (Unexpected internal server error)
       content:
@@ -619,6 +639,13 @@ components:
           reason: "INSUFFICIENT_FUNDS"
           details: "Unable to process request due to the lack of funds"
       summary: Response when access token run out of funds
+
+    CustomServiceErrorExample:
+      value:
+        error:
+          reason: "CUSTOM_ERROR_CODE_FOR_MACHINES"
+          details: "Optional explanation for humans with more details"
+      summary: Response when a custom error occured
 
     InternalServerErrorExample:
       value:


### PR DESCRIPTION
This PR:


-  removes reliance on HTTP semantics for error codes and switches to a generic `HTTP 400` with `Error` object in body that is returned with mandatory `reason` string and optional `details`, as proposed in https://github.com/ipfs/pinning-services-api-spec/issues/57

- Every endpoint now has only two response types: _success_ and _error_, and success has the name of returned object in its description, making the spec docs easier to read:

![2020-09-02--12-54-07](https://user-images.githubusercontent.com/157609/91972873-9b158480-ed1b-11ea-9a59-4400b0ebc1ad.png)


**PREVIEW:** https://ipfs.github.io/pinning-services-api-spec/#specUrl=https://raw.githubusercontent.com/ipfs/pinning-services-api-spec/feat/error-codes/ipfs-pinning-service.yaml


Closes #57 @obo20 @andrew  @GregTheGreek @priom @jsign  @sanderpick @andrewxhill @ipfs/wg-pinning-services 

Please provide feedback (even if its just :+1: / :-1:)