### PR TITLE
fix: adjust cid filter limits

### DIFF
--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -478,7 +478,7 @@ components:
           type: string
         uniqueItems: true
         minItems: 1
-        maxItems: 1000
+        maxItems: 10
       style: form # ?cid=Qm1,Qm2,bafy3
       explode: false
       example: ["Qm1","Qm2","bafy3"]

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -468,7 +468,7 @@ components:
         default: 10
 
     cid:
-      description: Return pin objects responsible for pinning the specified CID(s)
+      description: Return pin objects responsible for pinning the specified CID(s); be aware that using longer hash functions introduces further constraints on the number of CIDs that will fit under the limit of 2000 characters per URL  in browser contexts
       name: cid
       in: query
       required: false


### PR DESCRIPTION
This PR sets limit of 10 CIDs passed via `cid` filter to the `GET /pins` endpoint as suggested in #53

Closes #53 cc @obo20 @jacobheun  