### PR TITLE
refactor: rename PinStatus id → requestid

### DIFF
--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -35,7 +35,14 @@ A full list of fields and schemas can be found in the `schemas` section of the [
 
 ### requestid
 
-Unique identifier of a pin request. Multiple request can point at the same `cid` but have different `name` or other metadata attached, `requestid` is used for differentiating between them.
+Unique identifier of a pin request.
+
+
+When a pin is created the service responds with unique `requestid` that can be later used for pin removal. When the same `cid` is pinned again a different `requestid` is returned to differentiate between those pin requests.
+
+
+Service implementation should use UUID, `hash(accessToken,Pin,PinStatus.created)`, or any other opaque identifier that provides equally strong protection against race conditions.
+
 
 ## Objects
 

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -38,7 +38,7 @@ A full list of fields and schemas can be found in the `schemas` section of the [
 Unique identifier of a pin request.
 
 
-When a pin is created the service responds with unique `requestid` that can be later used for pin removal. When the same `cid` is pinned again a different `requestid` is returned to differentiate between those pin requests.
+When a pin is created the service responds with unique `requestid` that can be later used for pin removal. When the same `cid` is pinned again, a different `requestid` is returned to differentiate between those pin requests.
 
 
 Service implementation should use UUID, `hash(accessToken,Pin,PinStatus.created)`, or any other opaque identifier that provides equally strong protection against race conditions.

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -33,16 +33,16 @@ A full list of fields and schemas can be found in the `schemas` section of the [
 
 [Content Identifier (CID)](https://docs.ipfs.io/concepts/content-addressing/) points at the root of a DAG that is pinned recursively.
 
-### pid
+### requestid
 
-Unique identifier of a pin request. Multiple request can point at the same `cid` but have different `name` or other metadata attached, `pid` is used for differentiating between them.
+Unique identifier of a pin request. Multiple request can point at the same `cid` but have different `name` or other metadata attached, `requestid` is used for differentiating between them.
 
 ## Objects
 
 ### Pin object
 
 
-![pin object](https://bafybeigmmkhesreasirllvgzentfyegi5pws5pdqob3efi5d5win7v3loq.ipfs.dweb.link/pin.png)
+![pin object](https://bafybeideck2fchyxna4wqwc2mo67yriokehw3yujboc5redjdaajrk2fjq.ipfs.dweb.link/pin.png)
 
 
 The `Pin` object is a representation of a pin request.
@@ -54,26 +54,26 @@ It includes the `cid` of data to be pinned, as well as optional metadata in `nam
 ### Pin status response
 
 
-![pin status response object](https://bafybeigmmkhesreasirllvgzentfyegi5pws5pdqob3efi5d5win7v3loq.ipfs.dweb.link/pinstatus.png)
+![pin status response object](https://bafybeideck2fchyxna4wqwc2mo67yriokehw3yujboc5redjdaajrk2fjq.ipfs.dweb.link/pinstatus.png)
 
 
 The `PinStatus` object is a representation of the current state of a pinning operation.
 
-It includes the original `pin` object, along with the current `status` and globally unique `pid` of the entire pinning request, which can be used for future status checks and management.
+It includes the original `pin` object, along with the current `status` and globally unique `requestid` of the entire pinning request, which can be used for future status checks and management.
 Addresses in the `delegates` array are peers delegated by the pinning service for facilitating direct file transfers (more details in the provider hints section). Any additional vendor-specific information is returned in optional `info`.
 
 
 ## The pin lifecycle
 
 
-![pinning service objects and lifecycle](https://bafybeigmmkhesreasirllvgzentfyegi5pws5pdqob3efi5d5win7v3loq.ipfs.dweb.link/lifecycle.png)
+![pinning service objects and lifecycle](https://bafybeideck2fchyxna4wqwc2mo67yriokehw3yujboc5redjdaajrk2fjq.ipfs.dweb.link/lifecycle.png)
 
 
 ### Creating a new pin object
 
 The user sends a `Pin` object to `POST /pins` and receives a `PinStatus` response:
 
-- `pid` in `PinStatus` is the identifier of the pin operation, which can can be used for checking status, and removing the pin in the future
+- `requestid` in `PinStatus` is the identifier of the pin operation, which can can be used for checking status, and removing the pin in the future
 
 - `status` in `PinStatus` indicates the current state of a pin
 
@@ -83,17 +83,17 @@ The user sends a `Pin` object to `POST /pins` and receives a `PinStatus` respons
 `status` (in `PinStatus`) may indicate a pending state (`queued` or `pinning`). This means the data behind `Pin.cid` was not found on the pinning service and is being fetched from the IPFS network at large, which may take time.
 
 
-In this case, the user can periodically check pinning progress via `GET /pins/{pid}` until pinning is successful, or the user decides to remove the pending pin.
+In this case, the user can periodically check pinning progress via `GET /pins/{requestid}` until pinning is successful, or the user decides to remove the pending pin.
 
 
 ### Replacing an existing pin object
 
-The user can replace an existing pin object via `POST /pins/{pid}`. This is a shortcut for removing a pin object identified by `pid` and creating a new one in a single API call that protects against undesired garbage collection of blocks common to both pins. Useful when updating a pin representing a huge dataset where most of blocks did not change. The new pin object `pid` is returned in the `PinStatus` response. The old pin object is deleted automatically.
+The user can replace an existing pin object via `POST /pins/{requestid}`. This is a shortcut for removing a pin object identified by `requestid` and creating a new one in a single API call that protects against undesired garbage collection of blocks common to both pins. Useful when updating a pin representing a huge dataset where most of blocks did not change. The new pin object `requestid` is returned in the `PinStatus` response. The old pin object is deleted automatically.
 
 
 ### Removing a pin object
 
-A pin object can be removed via `DELETE /pins/{pid}`.
+A pin object can be removed via `DELETE /pins/{requestid}`.
 
 
 
@@ -240,9 +240,9 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
-  /pins/{pid}:
+  /pins/{requestid}:
     parameters:
-      - name: pid
+      - name: requestid
         in: path
         required: true
         schema:
@@ -339,13 +339,13 @@ components:
       description: Pin object with status
       type: object
       required:
-        - pid
+        - requestid
         - status
         - created
         - pin
         - delegates
       properties:
-        pid:
+        requestid:
           description: Globally unique identifier of the pin request; can be used to check the status of ongoing pinning, or pin removal
           type: string
           example: "UniqueIdOfPinRequest"

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -26,12 +26,23 @@ This section describes the most important object types and conventions.
 
 A full list of fields and schemas can be found in the `schemas` section of the [YAML file](https://github.com/ipfs/pinning-services-api-spec/blob/master/ipfs-pinning-service.yaml).
 
+
+## Identifiers
+
+### cid
+
+[Content Identifier (CID)](https://docs.ipfs.io/concepts/content-addressing/) points at the root of a DAG that is pinned recursively.
+
+### pid
+
+Unique identifier of a pin request. Multiple request can point at the same `cid` but have different `name` or other metadata attached, `pid` is used for differentiating between them.
+
 ## Objects
 
 ### Pin object
 
 
-![pinning-services-api-pin-object.png](https://bafybeidcoyxd723nakggdayy6qg25bl7mls3ilwwiyxmys5qpek7y6jwc4.ipfs.dweb.link/?filename=pinning-services-api-pin-object.png)
+![pin object](https://bafybeigmmkhesreasirllvgzentfyegi5pws5pdqob3efi5d5win7v3loq.ipfs.dweb.link/pin.png)
 
 
 The `Pin` object is a representation of a pin request.
@@ -43,26 +54,26 @@ It includes the `cid` of data to be pinned, as well as optional metadata in `nam
 ### Pin status response
 
 
-![pinning-services-api-pin-status-response.png](https://bafybeiec3c3gzsus4rksddsuxcybilex3odq5cm2cyrzrb7m3suwspl6uy.ipfs.dweb.link/?filename=pinning-services-api-pin-status-response.png)
+![pin status response object](https://bafybeigmmkhesreasirllvgzentfyegi5pws5pdqob3efi5d5win7v3loq.ipfs.dweb.link/pinstatus.png)
 
 
 The `PinStatus` object is a representation of the current state of a pinning operation.
 
-It includes the original `pin` object, along with the current `status` and globally unique `id` of the entire pinning request, which can be used for future status checks and management.
+It includes the original `pin` object, along with the current `status` and globally unique `pid` of the entire pinning request, which can be used for future status checks and management.
 Addresses in the `delegates` array are peers delegated by the pinning service for facilitating direct file transfers (more details in the provider hints section). Any additional vendor-specific information is returned in optional `info`.
 
 
 ## The pin lifecycle
 
 
-![pinning-services-api-objects.png](https://bafybeigyefq6vwfcsi7dfgqunf4uei426lvia3w73ylg4kgdwwg6txivpe.ipfs.dweb.link/?filename=pinning-services-api-objects.png)
+![pinning service objects and lifecycle](https://bafybeigmmkhesreasirllvgzentfyegi5pws5pdqob3efi5d5win7v3loq.ipfs.dweb.link/lifecycle.png)
 
 
 ### Creating a new pin object
 
 The user sends a `Pin` object to `POST /pins` and receives a `PinStatus` response:
 
-- `id` in `PinStatus` is the identifier of the pin operation, which can can be used for checking status, modifying the pin, and/or removing the pin in the future
+- `pid` in `PinStatus` is the identifier of the pin operation, which can can be used for checking status, and removing the pin in the future
 
 - `status` in `PinStatus` indicates the current state of a pin
 
@@ -72,17 +83,17 @@ The user sends a `Pin` object to `POST /pins` and receives a `PinStatus` respons
 `status` (in `PinStatus`) may indicate a pending state (`queued` or `pinning`). This means the data behind `Pin.cid` was not found on the pinning service and is being fetched from the IPFS network at large, which may take time.
 
 
-In this case, the user can periodically check pinning progress via `GET /pins/{id}` until pinning is successful, or the user decides to remove the pending pin.
+In this case, the user can periodically check pinning progress via `GET /pins/{pid}` until pinning is successful, or the user decides to remove the pending pin.
 
 
 ### Replacing an existing pin object
 
-The user can replace an existing pin object via `POST /pins/{id}`. This is a shortcut for removing a pin object identified by `id` and creating a new one in a single API call that protects against undesired garbage collection of blocks common to both pins. Useful when updating a pin representing a huge dataset where most of blocks did not change. The new pin object `id` is returned in the `PinStatus` response. The old pin object is deleted automatically.
+The user can replace an existing pin object via `POST /pins/{pid}`. This is a shortcut for removing a pin object identified by `pid` and creating a new one in a single API call that protects against undesired garbage collection of blocks common to both pins. Useful when updating a pin representing a huge dataset where most of blocks did not change. The new pin object `pid` is returned in the `PinStatus` response. The old pin object is deleted automatically.
 
 
 ### Removing a pin object
 
-A pin object can be removed via `DELETE /pins/{id}`.
+A pin object can be removed via `DELETE /pins/{pid}`.
 
 
 
@@ -229,9 +240,9 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
-  /pins/{id}:
+  /pins/{pid}:
     parameters:
-      - name: id
+      - name: pid
         in: path
         required: true
         schema:
@@ -328,14 +339,14 @@ components:
       description: Pin object with status
       type: object
       required:
-        - id
+        - pid
         - status
         - created
         - pin
         - delegates
       properties:
-        id:
-          description: Globally unique ID of the pin request; can be used to check the status of ongoing pinning, modification of pin object, or pin removal
+        pid:
+          description: Globally unique identifier of the pin request; can be used to check the status of ongoing pinning, or pin removal
           type: string
           example: "UniqueIdOfPinRequest"
         status:
@@ -359,7 +370,7 @@ components:
         - cid
       properties:
         cid:
-          description: CID to be pinned recursively
+          description: Content Identifier (CID) to be pinned recursively
           type: string
           example: "QmCIDToBePinned"
         name:


### PR DESCRIPTION
This is an attempt to clarify the difference between `cid` identifier in request and `id` in response:

- adds "Identifiers" section to the docs and clarifies purpose of each
- **BREAKING CHANGE:** `id` is renamed to `requestid`
  - I believe this will make it easier for people to reason `requestid` vs `cid`, but can restore old field name if community decides it is not worth the hassle.


**PREVIEW:** https://ipfs.github.io/pinning-services-api-spec/#specUrl=https://raw.githubusercontent.com/ipfs/pinning-services-api-spec/docs/pid/ipfs-pinning-service.yaml

cc @obo20 @andrew @aschmahmann  @GregTheGreek @priom @jsign  @sanderpick @andrewxhill @ipfs/wg-pinning-services 

Please provide feedback (even if its just :+1: / :-1:)