### PR TITLE
style: rename object returned with error

### DIFF
--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -461,8 +461,8 @@ components:
       example:
         status_details: "Queue position: 7 of 9" # PinStatus.info[status_details], when status=queued
 
-    Error:
-      description: Error object
+    Failure:
+      description: Response for a failed request
       type: object
       required:
         - error

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -573,7 +573,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/Error'
+            $ref: '#/components/schemas/Failure'
           examples:
             BadRequestExample:
               $ref: '#/components/examples/BadRequestExample'
@@ -583,7 +583,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/Error'
+            $ref: '#/components/schemas/Failure'
           examples:
             UnauthorizedExample:
               $ref: '#/components/examples/UnauthorizedExample'
@@ -593,7 +593,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/Error'
+            $ref: '#/components/schemas/Failure'
           examples:
             NotFoundExample:
               $ref: '#/components/examples/NotFoundExample'
@@ -603,7 +603,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/Error'
+            $ref: '#/components/schemas/Failure'
           examples:
             InsufficientFundsExample:
               $ref: '#/components/examples/InsufficientFundsExample'
@@ -613,7 +613,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/Error'
+            $ref: '#/components/schemas/Failure'
           examples:
             CustomServiceErrorExample:
               $ref: '#/components/examples/CustomServiceErrorExample'
@@ -623,7 +623,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/Error'
+            $ref: '#/components/schemas/Failure'
           examples:
             InternalServerErrorExample:
               $ref: '#/components/examples/InternalServerErrorExample'


### PR DESCRIPTION
This PR renames `Error` response object to `Failure`


The idea is to avoid ambiguous `ErrorError` in generated client code.
This does not change the JSON format sent between client and server.


cc @aschmahmann @andrew 