### PR TITLE
feat: fast exact name search by default

### DIFF
--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -202,6 +202,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/cid'
         - $ref: '#/components/parameters/name'
+        - $ref: '#/components/parameters/match'
         - $ref: '#/components/parameters/status'
         - $ref: '#/components/parameters/before'
         - $ref: '#/components/parameters/after'
@@ -406,7 +407,7 @@ components:
           description: Optional name for pinned data; can be used for lookups later
           type: string
           maxLength: 255
-          example: "my precious data"
+          example: "PreciousData.pdf"
         origins:
           $ref: '#/components/schemas/Origins'
         meta:
@@ -460,6 +461,14 @@ components:
         maxProperties: 1000
       example:
         status_details: "Queue position: 7 of 9" # PinStatus.info[status_details], when status=queued
+
+    TextMatchingStrategy:
+      description: Alternative text matching strategy
+      type: string
+      default: exact
+      enum:
+        - exact   # full match, case-sensitive (the implicit default)
+        - fuzzy   # partial match, case-insensitive
 
     Failure:
       description: Response for a failed request
@@ -532,14 +541,23 @@ components:
       example: ["Qm1","Qm2","bafy3"]
 
     name:
-      description: Return pin objects with names that contain provided value (case-insensitive, partial or full match)
+      description: Return pin objects with specified name (by default a case-sensitive, exact match)
       name: name
       in: query
       required: false
       schema:
         type: string
         maxLength: 255
-      example: "my precious"
+      example: "PreciousData.pdf"
+
+    match:
+      description: Customize the text matching strategy applied when name filter is present
+      name: match
+      in: query
+      required: false
+      schema:
+        $ref: '#/components/schemas/TextMatchingStrategy'
+      example: exact
 
     status:
       description: Return pin objects for pins with the specified status

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -467,8 +467,10 @@ components:
       type: string
       default: exact
       enum:
-        - exact   # full match, case-sensitive (the implicit default)
-        - partial # partial match, case-insensitive
+        - exact    # full match, case-sensitive (the implicit default)
+        - iexact   # full match, case-insensitive
+        - partial  # partial match, case-sensitive
+        - ipartial # partial match, case-insensitive
 
     Failure:
       description: Response for a failed request

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -468,7 +468,7 @@ components:
       default: exact
       enum:
         - exact   # full match, case-sensitive (the implicit default)
-        - fuzzy   # partial match, case-insensitive
+        - partial # partial match, case-insensitive
 
     Failure:
       description: Response for a failed request


### PR DESCRIPTION
# tldr

This PR changes the default behavior of the `name` filter 

from **case-insensitive, partial match** 
to much faster **case-sensitive, exact (full)  match**

and adds `match` parameter that enables opt-in into alternative strategy when performance is not an object:

> ![Screenshot_2020-10-26 IPFS Pinning Service API](https://user-images.githubusercontent.com/157609/97210699-4132b780-17be-11eb-809a-5747fcda0244.png)



**PREVIEW:** https://ipfs.github.io/pinning-services-api-spec/#specUrl=https://raw.githubusercontent.com/ipfs/pinning-services-api-spec/fix/default-to-fast-name-match/ipfs-pinning-service.yaml

# Rationale for this change

- **Case-insensitive partial "Fuzzy" search (`ipartial`) makes a bad default. (performance-wise)** 
  Database indexes and b-trees do not solve the performance fully.
  Exact match is always faster and less expensive.

- **Fuzzy search may produce bugs**
  This PR introduces `match` query parameter, so developers who need fuzzy search  can still opt-in into slower, but more flexible text matching strategy by passing `match` parameter. 

- **We are moving away from slow defaults in IPFS ecosystem. Better to do this now, than later.**
  - A good example of [tyranny of small decisions](https://en.wikipedia.org/wiki/Tyranny_of_small_decisions) is `ipfs pin ls`, which is  abysmally slow when one has >1k pins. Nearly all pins in real life are recursive, and `ipfs pin ls --type=recursive` executes instantly, but is rarely used due to not being the default. 
  - Future `ipfs pin remote` and `ipfs pin local` APIs will be inspired by this spec and will have `name` attribute, however we don't want to  re-introduce bad choices into IPFS ecosystem. The default should be the fastest option available, and in  this case it is the exact `name` match.


# Implementation notes and migration plan

- This change does not change the wire format and does not impact ongoing MVP integration in go-ipfs and ipfs-webui (https://github.com/ipfs/ipfs-gui/issues/91, https://github.com/ipfs/go-ipfs/issues/7559), but we want to include it in this spec to ensure MVP does the right thing.

- Existing Pinning Services already implement the more difficult <del>`fuzzy`</del> `ipartial` strategy. Adding support for `match` filter and implementing much simpler `exact` strategy should be a small task, but will save everyone headache in the long run.


---- 

@aschmahmann @jacobheun @petar @gammazero @obo20 @andrew  @GregTheGreek @priom @jsign  @sanderpick @andrewxhill @ipfs/wg-pinning-services 
