### PR TITLE
refactor: use exploded array parameters for 'cid' and 'status'

### DIFF
--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -538,8 +538,8 @@ components:
         uniqueItems: true
         minItems: 1
         maxItems: 10
-      style: form # ?cid=Qm1,Qm2,bafy3
-      explode: false
+      style: form # ?cid=Qm1&cid=Qm2&cid=bafy3
+      explode: true
       example: ["Qm1","Qm2","bafy3"]
 
     name:
@@ -572,8 +572,8 @@ components:
           $ref: '#/components/schemas/Status'
         uniqueItems: true
         minItems: 1
-      style: form # ?status=queued,pinning
-      explode: false
+      style: form # ?status=queued&status=pinning
+      explode: true
       example: ["queued","pinning"]
 
     meta:


### PR DESCRIPTION
> :point_right:  **This PR aims to facilitate discussion: we need to decide if we want to merge this or close and leave it as-is.**

This PR introduces (most likely) a BREAKING CHANGE: `cid` and `status` filters need to be passed differently:

- before: `?cid=Qm1%2CQm2` / `?cid=Qm1,Qm2` (comma separated)
- after: `?cid=Qm1&cid=Qm2` (multiple params)


**PREVIEW:** https://ipfs.github.io/pinning-services-api-spec/#specUrl=https://raw.githubusercontent.com/ipfs/pinning-services-api-spec/fix/explode-array-parameters/ipfs-pinning-service.yaml


------

## TLDR

Right now the Pinning Service API uses `?cid=Qm1,Qm2` notation for `cid` and `status` parameters.

This may not be the best choice because of:
1. url-escaping `,` into `%2C`
2. future CID encodings or new filters that could include `,` inside passed value

Potential solution is to switch to exploded notation: `?cid=Qm1&cid=Qm2` (this PR)

## Background

IIRC nobody had any strong opinions at the time, so we picked a notation that is short and human-readable.


While working on `pin remote` support in go-ipfs (https://github.com/ipfs/go-ipfs/pull/7661)  we realized additional nuance: clients generated from the [v0.1.2 spec](https://github.com/ipfs/pinning-services-api-spec/releases/tag/v0.1.2)  will automatically escape commas in the query parameter, which weakens the "human-readable" argument a bit:

```
GET /pins?status=queued%2Cpinned&cid=QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn%2CQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR&limit=10
```

This is because:

>  [RFC 3986](https://tools.ietf.org/html/rfc3986#section-2.2) defines a set of reserved characters `:/?#[]@!$&'()*+,;=` that are used as URI component delimiters. When these characters need to be used literally in a query parameter value, they are usually percent-encoded.  
>  If you want a query parameter that is not percent-encoded, add `allowReserved: true` to the parameter definition ([src](https://swagger.io/docs/specification/describing-parameters/))

Ref.  https://swagger.io/docs/specification/serialization/#query

## Why this is a problem

While `status` is an enum of four predefined states (`queues|pinning|pinned|failed`), the `cid` is an array of opaque strings. Most of CIDs today are encoded in Base58btc or base-insensitive Base32/36, however it is possible that in the future IPFS will add support for base encoding that includes `,` in its alphabet, which introduces some ambiguity. 

In practice, it is not a big deal:
- there is no encoding with `,` right now
- if such encoding exists in the future, one can easily convert CID to arbitrary base via `ipfs cid format -b` before sending it to a pinning service

However:
- we may want to add new array parameters in the future
- if we can avoid this type of edge case at the API spec level, perhaps we should? 

OpenAPI supports many notations, and exploded one removes ambiguity by replacing commas with multiple query params:

![2020-11-25--15-39-01](https://user-images.githubusercontent.com/157609/100242268-e911e100-2f34-11eb-85ab-83baecc7307e.png)

## We ned to make a decision

Should we:

- (A) keep `?cid=Qm1%2CQm2` notation (close this PR, keep `explode: false`)

or is it better to

- (B) switch to `?cid=Qm1&cid=Qm2` (multiple params), which removes the ambiguity  (this PR, switch to `explode: true`)

Thoughts?

Note that I don't feel strongly about this, but failed to find any documented decision why we went with commas.
Think about his PR as a good opportunity to formalize the decision before we freeze the API.

Please comment if you don't think making the change is worth it, or if you see technical argument against exploded notation (lack of support in frameworks, libraries, etc).

@aschmahmann @achingbrain  @jacobheun @petar @gammazero @obo20 @andrew  @GregTheGreek @priom @jsign  @sanderpick @andrewxhill @ipfs/wg-pinning-services  @Gozala
