### PR TITLE
docs: improve Pin.origins example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+super-linter.log

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -430,7 +430,7 @@ components:
       uniqueItems: true
       minItems: 1
       maxItems: 20
-      example: ['/dnsaddr/pin-service.example.com']
+      example: ['/dnsaddr/pin-service.example.com/p2p/QmServicePeerId','/ip4/9.8.7.6/tcp/4001/p2p/QmServicePeerId','/ip4/5.4.3.1/udp/4001/quic/p2p/QmServicePeerId']
 
     Origins:
       description: Optional list of multiaddrs known to provide the data
@@ -440,7 +440,7 @@ components:
       uniqueItems: true
       minItems: 0
       maxItems: 20
-      example: ['/ip4/1.2.3.4/tcp/4001/p2p/QmSourcePeerId','/ip4/5.6.7.8/udp/4001/quic/p2p/QmSourcePeerId','/dnsaddr/ipfs-nodes.example.com']
+      example: ['/ip4/1.2.3.4/tcp/4001/p2p/QmSourcePeerId','/ip4/5.6.7.8/udp/4001/quic/p2p/QmSourcePeerId']
 
     PinMeta:
       description: Optional metadata for pin object

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -440,7 +440,7 @@ components:
       uniqueItems: true
       minItems: 0
       maxItems: 20
-      example: ['/p2p/QmSourcePeerId']
+      example: ['/ip4/1.2.3.4/tcp/4001/p2p/QmSourcePeerId','/ip4/5.6.7.8/udp/4001/quic/p2p/QmSourcePeerId','/dnsaddr/ipfs-nodes.example.com']
 
     PinMeta:
       description: Optional metadata for pin object


### PR DESCRIPTION
This updates example in docs to show that multiple multiaddrs  of different types can be added:

> ![2020-11-30--23-23-36](https://user-images.githubusercontent.com/157609/100673332-9042ae00-3363-11eb-9df1-5f678842550e.png)


Thanks @obo20 for noticing this.