### PR TITLE
docs: clarify use of provider hints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+super-linter.log

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -108,7 +108,7 @@ A pin object can be removed via `DELETE /pins/{requestid}`.
 
 A pinning service will use the DHT and other discovery methods to locate pinned
 content; however, it is a good practice to provide additional provider hints to
-speedup the discovery phase and start the transfer immediately, especially if a
+speed up the discovery phase and start the transfer immediately, especially if a
 client has the data in own datastore, or knows of other providers already.
 
 

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -131,6 +131,11 @@ pinning operation. When unable to act on explicit provider hints, DHT and
 other discovery methods should be used as a fallback by a pinning service.
 
 
+**NOTE:** All multiaddrs MUST end with `/p2p/{peerID}` and SHOULD be fully
+resolved and confirmed to be dialable from the public internet. Avoid sending
+addresses from local networks.
+
+
 ## Custom metadata
 
 Pinning services are encouraged to add support for additional features by leveraging the optional `Pin.meta` and `PinStatus.info` fields.
@@ -450,7 +455,7 @@ components:
       uniqueItems: true
       minItems: 0
       maxItems: 20
-      example: ['/ip4/192.0.2.42/tcp/4001/p2p/QmSourcePeerId', '/ip4/198.51.100.14/udp/4001/quic/p2p/QmSourcePeerId']
+      example: ['/ip4/203.0.113.142/tcp/4001/p2p/QmSourcePeerId', '/ip4/203.0.113.114/udp/4001/quic/p2p/QmSourcePeerId']
 
     PinMeta:
       description: Optional metadata for pin object

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -120,8 +120,9 @@ in `Pin.origins`.
 
 
 This ensures data transfer starts immediately (without waiting for provider
-discovery over DHT), and direct dial from a client works around peer routing
-issues in restrictive network topologies, such as NATs, firewalls, etc.
+discovery over DHT), and mutual direct dial between a client and a service
+works around peer routing issues in restrictive network topologies, such as
+NATs, firewalls, etc.
 
 
 **NOTE:** Connections to multiaddrs in `origins` and `delegates` arrays should

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -115,7 +115,7 @@ client has the data in their own datastore or already knows of other providers.
 The most common scenario is a client putting its own IPFS node's multiaddrs in
 `Pin.origins`,  and then attempt to connect to every multiaddr returned by a
 pinning service in `PinStatus.delegates` to initiate transfer.  At the same
-time, pinning service will try to connect to multiaddrs provided by the client
+time, a pinning service will try to connect to multiaddrs provided by the client
 in  `Pin.origins`.
 
 

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -121,7 +121,7 @@ in  `Pin.origins`.
 
 This ensures data transfer starts immediately (without waiting for provider
 discovery over DHT), and direct dial from a client works around peer routing
-issues in restrictive network topologies such as NATs, firewalls etc.
+issues in restrictive network topologies, such as NATs, firewalls, etc.
 
 
 **NOTE:** connections to multiaddrs in `origins` and `delegates` arrays should

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -70,13 +70,13 @@ It includes the original `pin` object, along with the current `status` and globa
 Addresses in the `delegates` array are peers delegated by the pinning service for facilitating direct file transfers (more details in the provider hints section). Any additional vendor-specific information is returned in optional `info`.
 
 
-## The pin lifecycle
+# The pin lifecycle
 
 
 ![pinning service objects and lifecycle](https://bafybeideck2fchyxna4wqwc2mo67yriokehw3yujboc5redjdaajrk2fjq.ipfs.dweb.link/lifecycle.png)
 
 
-### Creating a new pin object
+## Creating a new pin object
 
 The user sends a `Pin` object to `POST /pins` and receives a `PinStatus` response:
 
@@ -85,7 +85,7 @@ The user sends a `Pin` object to `POST /pins` and receives a `PinStatus` respons
 - `status` in `PinStatus` indicates the current state of a pin
 
 
-### Checking status of in-progress pinning
+## Checking status of in-progress pinning
 
 `status` (in `PinStatus`) may indicate a pending state (`queued` or `pinning`). This means the data behind `Pin.cid` was not found on the pinning service and is being fetched from the IPFS network at large, which may take time.
 
@@ -93,18 +93,18 @@ The user sends a `Pin` object to `POST /pins` and receives a `PinStatus` respons
 In this case, the user can periodically check pinning progress via `GET /pins/{requestid}` until pinning is successful, or the user decides to remove the pending pin.
 
 
-### Replacing an existing pin object
+## Replacing an existing pin object
 
 The user can replace an existing pin object via `POST /pins/{requestid}`. This is a shortcut for removing a pin object identified by `requestid` and creating a new one in a single API call that protects against undesired garbage collection of blocks common to both pins. Useful when updating a pin representing a huge dataset where most of blocks did not change. The new pin object `requestid` is returned in the `PinStatus` response. The old pin object is deleted automatically.
 
 
-### Removing a pin object
+## Removing a pin object
 
 A pin object can be removed via `DELETE /pins/{requestid}`.
 
 
 
-## Provider hints
+# Provider hints
 
 A pinning service will use the DHT and other discovery methods to locate pinned
 content; however, it is a good practice to provide additional provider hints to
@@ -136,12 +136,12 @@ resolved and confirmed to be dialable from the public internet. Avoid sending
 addresses from local networks.
 
 
-## Custom metadata
+# Custom metadata
 
 Pinning services are encouraged to add support for additional features by leveraging the optional `Pin.meta` and `PinStatus.info` fields.
 While these attributes can be application- or vendor-specific, we encourage the community at large to leverage these attributes as a sandbox to come up with conventions that could become part of future revisions of this API.
 
-### Pin metadata
+## Pin metadata
 
 String keys and values passed in `Pin.meta` are persisted with the pin object.
 
@@ -156,7 +156,7 @@ Potential uses:
 Note that it is OK for a client to omit or ignore these optional attributes; doing so should not impact the basic pinning functionality.
 
 
-### Pin status info
+## Pin status info
 
 Additional `PinStatus.info` can be returned by pinning service.
 

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -106,19 +106,28 @@ A pin object can be removed via `DELETE /pins/{requestid}`.
 
 ## Provider hints
 
-Pinning of new data can be accelerated by providing a list of known data
-sources in `Pin.origins`, and connecting at least one of them to pinning
-service nodes at `PinStatus.delegates`.
+Pinning service will use DHT and other discovery methods to locate pinned
+content, however it is a good practice to provide additional provider hints to
+speedup the discovery phase and start the transfer immediately, especially if a
+client has the data in own datastore, or knows of other providers already.
 
 
 The most common scenario is a client putting its own IPFS node's multiaddrs in
-`Pin.origins`,  and then directly connecting to every multiaddr returned by
-a pinning service in `PinStatus.delegates` to initiate transfer.
+`Pin.origins`,  and then attempt to connect to every multiaddr returned by a
+pinning service in `PinStatus.delegates` to initiate transfer.  At the same
+time, pinning service will try to connect to multiaddrs provided by the client
+in  `Pin.origins`.
 
 
 This ensures data transfer starts immediately (without waiting for provider
 discovery over DHT), and direct dial from a client works around peer routing
-issues in restrictive network topologies such as NATs.
+issues in restrictive network topologies such as NATs, firewalls etc.
+
+
+**NOTE:** connections to multiaddrs in `origins` and `delegates` arrays should
+be attempted in best-effort fashion, and dial failure should not fail the
+pinning operation. When unable to act on explicit provider hints,  DHT and
+other discovery methods should be used as a fallback by pinning service.
 
 
 ## Custom metadata
@@ -430,7 +439,7 @@ components:
       uniqueItems: true
       minItems: 1
       maxItems: 20
-      example: ['/dnsaddr/pin-service.example.com']
+      example: ['/ip4/203.0.113.1/tcp/4001/p2p/QmServicePeerId']
 
     Origins:
       description: Optional list of multiaddrs known to provide the data
@@ -440,7 +449,7 @@ components:
       uniqueItems: true
       minItems: 0
       maxItems: 20
-      example: ['/p2p/QmSourcePeerId']
+      example: ['/ip4/192.0.2.42/tcp/4001/p2p/QmSourcePeerId', '/ip4/198.51.100.14/udp/4001/quic/p2p/QmSourcePeerId']
 
     PinMeta:
       description: Optional metadata for pin object

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -126,7 +126,7 @@ issues in restrictive network topologies, such as NATs, firewalls, etc.
 
 **NOTE:** Connections to multiaddrs in `origins` and `delegates` arrays should
 be attempted in best-effort fashion, and dial failure should not fail the
-pinning operation. When unable to act on explicit provider hints,  DHT and
+pinning operation. When unable to act on explicit provider hints, DHT and
 other discovery methods should be used as a fallback by pinning service.
 
 

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -116,7 +116,7 @@ The most common scenario is a client putting its own IPFS node's multiaddrs in
 `Pin.origins`,  and then attempt to connect to every multiaddr returned by a
 pinning service in `PinStatus.delegates` to initiate transfer.  At the same
 time, a pinning service will try to connect to multiaddrs provided by the client
-in  `Pin.origins`.
+in `Pin.origins`.
 
 
 This ensures data transfer starts immediately (without waiting for provider

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -107,7 +107,7 @@ A pin object can be removed via `DELETE /pins/{requestid}`.
 ## Provider hints
 
 A pinning service will use the DHT and other discovery methods to locate pinned
-content, however it is a good practice to provide additional provider hints to
+content; however, it is a good practice to provide additional provider hints to
 speedup the discovery phase and start the transfer immediately, especially if a
 client has the data in own datastore, or knows of other providers already.
 

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -106,7 +106,7 @@ A pin object can be removed via `DELETE /pins/{requestid}`.
 
 ## Provider hints
 
-Pinning service will use DHT and other discovery methods to locate pinned
+A pinning service will use the DHT and other discovery methods to locate pinned
 content, however it is a good practice to provide additional provider hints to
 speedup the discovery phase and start the transfer immediately, especially if a
 client has the data in own datastore, or knows of other providers already.

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -124,7 +124,7 @@ discovery over DHT), and direct dial from a client works around peer routing
 issues in restrictive network topologies, such as NATs, firewalls, etc.
 
 
-**NOTE:** connections to multiaddrs in `origins` and `delegates` arrays should
+**NOTE:** Connections to multiaddrs in `origins` and `delegates` arrays should
 be attempted in best-effort fashion, and dial failure should not fail the
 pinning operation. When unable to act on explicit provider hints,  DHT and
 other discovery methods should be used as a fallback by pinning service.

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -109,7 +109,7 @@ A pin object can be removed via `DELETE /pins/{requestid}`.
 A pinning service will use the DHT and other discovery methods to locate pinned
 content; however, it is a good practice to provide additional provider hints to
 speed up the discovery phase and start the transfer immediately, especially if a
-client has the data in own datastore, or knows of other providers already.
+client has the data in their own datastore or already knows of other providers.
 
 
 The most common scenario is a client putting its own IPFS node's multiaddrs in

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -127,7 +127,7 @@ issues in restrictive network topologies, such as NATs, firewalls, etc.
 **NOTE:** Connections to multiaddrs in `origins` and `delegates` arrays should
 be attempted in best-effort fashion, and dial failure should not fail the
 pinning operation. When unable to act on explicit provider hints, DHT and
-other discovery methods should be used as a fallback by pinning service.
+other discovery methods should be used as a fallback by a pinning service.
 
 
 ## Custom metadata


### PR DESCRIPTION
This PR updates docs and examples related to `origins` and `delegates` multiaddr arrays:

- makes it explicit that connection dials to origins and delegates are   best-effort, and should not fail the pinning
- swaps examples to use fully resolved multiaddrs, that can immediately  be acted upon (IPs from test ranges  defined in [rfc5737](https://tools.ietf.org/html/rfc5737))


Thanks to @obo20 for raising the ambiguity here – lmk if this clears things out.