### PR TITLE
docs: clarify Pin.origins persistence

### DIFF
--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -73,6 +73,7 @@ The `Pin` object is a representation of a pin request.
 
 
 It includes the `cid` of data to be pinned, as well as optional metadata in `name`, `origins`, and `meta`.
+Addresses provided in `origins` list are relevant only during the initial pinning, and don't need to be persisted by the pinning service.
 
 
 ### Pin status response
@@ -83,7 +84,7 @@ It includes the `cid` of data to be pinned, as well as optional metadata in `nam
 
 The `PinStatus` object is a representation of the current state of a pinning operation.
 
-It includes the original `pin` object, along with the current `status` and globally unique `requestid` of the entire pinning request, which can be used for future status checks and management.
+It includes values from the original `Pin` object, along with the current `status` and globally unique `requestid` of the entire pinning request, which can be used for future status checks and management.
 Addresses in the `delegates` array are peers delegated by the pinning service for facilitating direct file transfers (more details in the provider hints section). Any additional vendor-specific information is returned in optional `info`.
 
 


### PR DESCRIPTION
This PR is doc-only change that clarifies that pinning services don't need to persist `Pin.origins` 

The rationale here is that 
- IPFS node can have many multiaddrs and storing them with every pin introduces unnecessary storage costs, as clients like `pin remote add` from go-ipfs  will put all mulltiaddrs of the local node
- Multiaddrs from `origins` are relevant only during the pinning operation, to speed up discovery of providers of mising blocks. 
- If user wants to persist "source peer"  they can add them to `meta` map instead

cc @obo20 (pinata) @whyrusleeping (estuary)