### PR TITLE
docs: document default status filter

### DIFF
--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -641,7 +641,7 @@ components:
       example: exact
 
     status:
-      description: Return pin objects for pins with the specified status
+      description: Return pin objects for pins with the specified status (when missing, service should default to pinned only)
       name: status
       in: query
       required: false


### PR DESCRIPTION
Clarifies what is the implicit default – ambiguity pointed out by @alanshaw – thanks!