### PR TITLE
feat: add `operationId`s

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,11 +1,10 @@
 ---
-name: Lint
+name: lint
 on:
   push:
 
 jobs:
-  build:
-    name: Lint
+  super-linter:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
@@ -16,3 +15,12 @@ jobs:
           VALIDATE_ALL_CODEBASE: true
           VALIDATE_OPENAPI: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  spectral-cli:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 'lts/*'
+      - run: npx @stoplight/spectral-cli lint ./ipfs-pinning-service.yaml

--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -1,0 +1,1 @@
+extends: spectral:oas

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+all: lint-spectral lint-openapi
 
+
+lint-spectral:
+	npx @stoplight/spectral-cli lint ./ipfs-pinning-service.yaml
 lint-openapi:
 	docker run --rm -e RUN_LOCAL=true -e VALIDATE_OPENAPI=true -v $(shell pwd):/tmp/lint github/super-linter:v4

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -4,6 +4,9 @@ info:
   title: 'IPFS Pinning Service API'
   x-logo:
     url: "https://bafybeidehxarrk54mkgyl5yxbgjzqilp6tkaz2or36jhq24n3rdtuven54.ipfs.dweb.link/?filename=ipfs-pinning-service.svg"
+  contact:
+    name: IPFS
+    url: https://github.com/ipfs/pinning-services-api-spec
   description: "
   
   
@@ -271,9 +274,13 @@ Pin objects can be listed by executing `GET /pins` with optional parameters:
 servers:
   - url: https://pinning-service.example.com
 
+tags:
+  - name: pins
+
 paths:
   /pins:
     get:
+      operationId: getPins
       summary: List pin objects
       description: List all the pin objects, matching optional filters; when no filter is provided, only successful pins are returned
       tags:
@@ -307,6 +314,7 @@ paths:
         '5XX':
           $ref: '#/components/responses/InternalServerError'
     post:
+      operationId: addPin
       summary: Add pin object
       description: Add a new pin object for the current access token
       tags:
@@ -345,6 +353,7 @@ paths:
         schema:
           type: string
     get:
+      operationId: getPinByRequestId
       summary: Get pin object
       description: Get a pin object and its status
       tags:
@@ -369,6 +378,7 @@ paths:
         '5XX':
           $ref: '#/components/responses/InternalServerError'
     post:
+      operationId: replacePinByRequestId
       summary: Replace pin object
       description: Replace an existing pin object (shortcut for executing remove and add operations in one step to avoid unnecessary garbage collection of blocks present in both recursive pins)
       tags:
@@ -399,6 +409,7 @@ paths:
         '5XX':
           $ref: '#/components/responses/InternalServerError'
     delete:
+      operationId: deletePinByRequestId
       summary: Remove pin object
       description: Remove a pin object
       tags:


### PR DESCRIPTION
adds `operationId` properties to all routes. These can be used by code generators like `openapi-backend` to map routes to method names.

> Unique string used to identify the operation. The id MUST be unique among all operations described in the API. The operationId value is case-sensitive. Tools and libraries MAY use the operationId to uniquely identify an operation, therefore, it is RECOMMENDED to follow common programming naming conventions.
> – https://swagger.io/specification/#operation-object

> Handlers are registered for [operationIds](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#fixed-fields-8) found in the OpenAPI definitions.
> – https://github.com/anttiviljami/openapi-backend#registering-handlers-for-operations

also fixes the linting warnings:
- adds contact details to info object
- define the available tags before use
- add operationId for each operation

```console
$ npx @stoplight/spectral-cli lint ./ipfs-pinning-service.yaml

/Users/oli/Code/ipfs/pinning-services-api-spec/ipfs-pinning-service.yaml
   2:6   warning  info-contact           Info object must have "contact" object.         info
  276:9  warning  operation-operationId  Operation must have "operationId".              paths./pins.get
 280:11  warning  operation-tag-defined  Operation tags must be defined in global tags.  paths./pins.get.tags[0]
 309:10  warning  operation-operationId  Operation must have "operationId".              paths./pins.post
 313:11  warning  operation-tag-defined  Operation tags must be defined in global tags.  paths./pins.post.tags[0]
  347:9  warning  operation-operationId  Operation must have "operationId".              paths./pins/{requestid}.get
 351:11  warning  operation-tag-defined  Operation tags must be defined in global tags.  paths./pins/{requestid}.get.tags[0]
 371:10  warning  operation-operationId  Operation must have "operationId".              paths./pins/{requestid}.post
 375:11  warning  operation-tag-defined  Operation tags must be defined in global tags.  paths./pins/{requestid}.post.tags[0]
 401:12  warning  operation-operationId  Operation must have "operationId".              paths./pins/{requestid}.delete
 405:11  warning  operation-tag-defined  Operation tags must be defined in global tags.  paths./pins/{requestid}.delete.tags[0]

✖ 11 problems (0 errors, 11 warnings, 0 infos, 0 hints)
```

License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>