### PR TITLE
docs: date-time example with time-secfrac

### DIFF
--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -478,7 +478,7 @@ components:
           description: Immutable timestamp indicating when a pin request entered a pinning service; can be used for filtering results and pagination
           type: string
           format: date-time  # RFC 3339, section 5.6
-          example: "2020-07-27T17:32:28Z"
+          example: "2020-07-27T17:32:28.276Z"
         pin:
           $ref: '#/components/schemas/Pin'
         delegates:
@@ -595,7 +595,7 @@ components:
       schema:
         type: string
         format: date-time  # RFC 3339, section 5.6
-      example: "2020-07-27T17:32:28Z"
+      example: "2020-07-27T17:32:28.276Z"
 
     after:
       description: Return results created (queued) after provided timestamp
@@ -605,7 +605,7 @@ components:
       schema:
         type: string
         format: date-time  # RFC 3339, section 5.6
-      example: "2020-07-27T17:32:28Z"
+      example: "2020-07-27T17:32:28.276Z"
 
     limit:
       description: Max records to return


### PR DESCRIPTION
This PR does not change the spec, it only updates `date-time` examples to use time-secfrac from [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6).

Improved precision is already supported by the spec,  but the lack of explicit example made some implementations  round things to a full second, causing issues like https://github.com/ipfs/kubo/issues/8762.