### PR TITLE
docs: update status docs in ipfs-pinning-service.yaml

### DIFF
--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -111,11 +111,12 @@ The user sends a `Pin` object to `POST /pins` and receives a `PinStatus` respons
 `status` (in `PinStatus`) may indicate one of the two pending states: `queued` or `pinning`:
 
 - `queued` is passive: the pin was added to the queue but the service isn't consuming any resources to retrieve it yet.
+
 - `pinning` is active: the pinning service is trying to retrieve the CIDs by finding providers for all involved CIDs, connect to these providers and download data from them.
 
 When a new pin object is created it typically starts in a `queued` state. Once the pinning service actively seeks to retrieve the file it changes to `pinning`. `pinning` typically means that the data behind `Pin.cid` was not found on the pinning service and is being fetched from the IPFS network at large, which may take time.
 
-In either case, the user can periodically check pinning progress via `GET /pins/{requestid}` until pinning is successful, or the user decides to remove the pending pin.
+In either case, the user can periodically check pinning progress via `GET /pins/{requestid}` until pinning is `pinned` or `failed`, or the user decides to remove the pending pin.
 
 ## Replacing an existing pin object
 


### PR DESCRIPTION
Updating the formatting so get better layout at https://ipfs.github.io/pinning-services-api-spec/#section/The-pin-lifecycle/Checking-status-of-in-progress-pinning

I'm trying to fix this:
<img width="899" height="307" alt="image" src="https://github.com/user-attachments/assets/0bb1afff-88c1-43e2-9f6a-ec86dde6bb0a" />
